### PR TITLE
Improve startup reliability, gateway consistency, domain event dispatch, and integration test coverage

### DIFF
--- a/ELearning.API/Infrastructure/DatabaseInitializer.cs
+++ b/ELearning.API/Infrastructure/DatabaseInitializer.cs
@@ -1,0 +1,27 @@
+using ELearning.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace ELearning.API.Infrastructure;
+
+public static class DatabaseInitializer
+{
+    private const string SqlServerProvider = "SqlServer";
+
+    public static bool ShouldApplyMigrations(string? provider) =>
+        string.Equals(provider, SqlServerProvider, StringComparison.OrdinalIgnoreCase);
+
+    public static async Task InitializeAsync(IServiceProvider services, IConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var provider = configuration["Database:Provider"];
+
+        if (ShouldApplyMigrations(provider))
+        {
+            await dbContext.Database.MigrateAsync(cancellationToken);
+            return;
+        }
+
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+    }
+}

--- a/ELearning.API/Infrastructure/OcelotGatewayMode.cs
+++ b/ELearning.API/Infrastructure/OcelotGatewayMode.cs
@@ -1,0 +1,7 @@
+namespace ELearning.API.Infrastructure;
+
+public static class OcelotGatewayMode
+{
+    public static bool IsEnabled(IConfiguration configuration) =>
+        configuration.GetValue<bool>("Ocelot:Enabled");
+}

--- a/ELearning.API/Middleware/GlobalExceptionMiddleware.cs
+++ b/ELearning.API/Middleware/GlobalExceptionMiddleware.cs
@@ -1,0 +1,60 @@
+using ELearning.Application.Common.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ELearning.API.Middleware;
+
+public sealed class GlobalExceptionMiddleware(RequestDelegate next, ILogger<GlobalExceptionMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception exception)
+        {
+            await HandleExceptionAsync(context, exception);
+        }
+    }
+
+    private async Task HandleExceptionAsync(HttpContext context, Exception exception)
+    {
+        var (statusCode, title) = exception switch
+        {
+            ValidationException => (StatusCodes.Status400BadRequest, "Validation failed"),
+            NotFoundException => (StatusCodes.Status404NotFound, "Resource not found"),
+            ForbiddenAccessException => (StatusCodes.Status403Forbidden, "Forbidden"),
+            UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
+            DomainApplicationException => (StatusCodes.Status400BadRequest, "Application error"),
+            _ => (StatusCodes.Status500InternalServerError, "Internal server error")
+        };
+
+        if (statusCode >= 500)
+        {
+            logger.LogError(exception, "Unhandled exception for request {Method} {Path}", context.Request.Method, context.Request.Path);
+        }
+        else
+        {
+            logger.LogWarning(exception, "Handled exception for request {Method} {Path}", context.Request.Method, context.Request.Path);
+        }
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = exception.Message,
+            Instance = context.Request.Path
+        };
+
+        problemDetails.Extensions["traceId"] = context.TraceIdentifier;
+
+        if (exception is ValidationException validationException)
+        {
+            problemDetails.Extensions["errors"] = validationException.Errors;
+        }
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/problem+json";
+        await context.Response.WriteAsJsonAsync(problemDetails);
+    }
+}

--- a/ELearning.API/Program.cs
+++ b/ELearning.API/Program.cs
@@ -1,5 +1,6 @@
 using ELearning.API.GraphQL;
 using ELearning.API.Facades;
+using ELearning.API.Middleware;
 using ELearning.Application;
 using ELearning.Infrastructure;
 using ELearning.Infrastructure.Data;
@@ -171,15 +172,12 @@ using (var scope = app.Services.CreateScope())
 }
 
 // Configure the HTTP request pipeline
-if (app.Environment.IsDevelopment())
+if (!app.Environment.IsDevelopment())
 {
-    app.UseDeveloperExceptionPage();
-}
-else
-{
-    app.UseExceptionHandler("/Error");
     app.UseHsts();
 }
+
+app.UseMiddleware<GlobalExceptionMiddleware>();
 
 app.UseSwagger();
 app.UseSwaggerUI(c =>

--- a/ELearning.API/Program.cs
+++ b/ELearning.API/Program.cs
@@ -1,9 +1,9 @@
 using ELearning.API.GraphQL;
 using ELearning.API.Facades;
+using ELearning.API.Infrastructure;
 using ELearning.API.Middleware;
 using ELearning.Application;
 using ELearning.Infrastructure;
-using ELearning.Infrastructure.Data;
 using ELearning.Infrastructure.DaprServices;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -165,11 +165,7 @@ builder.Services.AddScoped<IApiFacade, ApiFacade>();
 // Build the app
 var app = builder.Build();
 
-using (var scope = app.Services.CreateScope())
-{
-    var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-    await dbContext.Database.EnsureCreatedAsync();
-}
+await DatabaseInitializer.InitializeAsync(app.Services, app.Configuration);
 
 // Configure the HTTP request pipeline
 if (!app.Environment.IsDevelopment())

--- a/ELearning.API/Program.cs
+++ b/ELearning.API/Program.cs
@@ -10,11 +10,13 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Ocelot.Cache.CacheManager;
 using Ocelot.DependencyInjection;
+using Ocelot.Middleware;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
+var ocelotGatewayEnabled = OcelotGatewayMode.IsEnabled(builder.Configuration);
 
 // Add application layer
 builder.Services.AddApplication();
@@ -76,9 +78,12 @@ builder.Services.AddCors(options =>
         });
 });
 
-// Add Ocelot
-builder.Services.AddOcelot(builder.Configuration)
-    .AddCacheManager(settings => settings.WithDictionaryHandle());
+// Add Ocelot only when running in gateway mode
+if (ocelotGatewayEnabled)
+{
+    builder.Services.AddOcelot(builder.Configuration)
+        .AddCacheManager(settings => settings.WithDictionaryHandle());
+}
 
 // Add authentication
 var jwtSettings = builder.Configuration.GetSection("JwtSettings");
@@ -189,9 +194,16 @@ app.UseCors("CorsPolicy");
 app.UseAuthentication();
 app.UseAuthorization();
 
-// Map endpoints
-app.MapControllers(); // REST API endpoints
-app.MapGraphQL();     // GraphQL endpoint at /graphql
+// Map endpoints for monolith mode; gateway mode delegates to Ocelot pipeline.
+if (!ocelotGatewayEnabled)
+{
+    app.MapControllers(); // REST API endpoints
+    app.MapGraphQL();     // GraphQL endpoint at /graphql
+}
+else
+{
+    await app.UseOcelot();
+}
 
 // Run the app
 app.Run();

--- a/ELearning.API/appsettings.Development.json
+++ b/ELearning.API/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Ocelot": {
+    "Enabled": false
+  },
   "Database": {
     "Provider": "SqliteInMemory",
     "SqliteInMemoryConnection": "Data Source=:memory:;Cache=Shared"

--- a/ELearning.API/appsettings.json
+++ b/ELearning.API/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "Ocelot": {
+    "Enabled": false
+  },
   "Database": {
     "Provider": "SqliteInMemory",
     "SqliteInMemoryConnection": "Data Source=:memory:;Cache=Shared"

--- a/ELearning.Application.Tests/Security/CurrentUserAuthorizationGuardTests.cs
+++ b/ELearning.Application.Tests/Security/CurrentUserAuthorizationGuardTests.cs
@@ -1,0 +1,209 @@
+using ELearning.Application.Common.Exceptions;
+using ELearning.Application.Common.Interfaces;
+using ELearning.Application.Common.Security;
+using ELearning.Domain.Entities.CourseAggregate;
+using ELearning.Domain.Entities.CourseAggregate.Abstractions.Repositories;
+using ELearning.Domain.Entities.CourseAggregate.Enums;
+using ELearning.Domain.ValueObjects;
+using ELearning.SharedKernel.Models;
+using FluentAssertions;
+
+namespace ELearning.Application.Tests.Security;
+
+public sealed class CurrentUserAuthorizationGuardTests
+{
+    [Fact]
+    public void EnsureAuthenticated_WhenUserIsNotAuthenticated_ThrowsForbiddenAccessException()
+    {
+        var currentUser = new FakeCurrentUserService(null, isAuthenticated: false);
+
+        var action = () => CurrentUserAuthorizationGuard.EnsureAuthenticated(currentUser);
+
+        action.Should().Throw<ForbiddenAccessException>();
+    }
+
+    [Fact]
+    public void EnsureStudentSelfOrAdmin_WhenCurrentUserIsRequestedStudent_DoesNotThrow()
+    {
+        var studentId = Guid.NewGuid();
+        var currentUser = new FakeCurrentUserService(studentId, isAuthenticated: true);
+
+        var action = () => CurrentUserAuthorizationGuard.EnsureStudentSelfOrAdmin(currentUser, studentId);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnsureStudentSelfOrAdmin_WhenCurrentUserIsAdmin_DoesNotThrow()
+    {
+        var currentUser = new FakeCurrentUserService(Guid.NewGuid(), isAuthenticated: true, roles: ["Admin"]);
+
+        var action = () => CurrentUserAuthorizationGuard.EnsureStudentSelfOrAdmin(currentUser, Guid.NewGuid());
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnsureStudentSelfOrAdmin_WhenCurrentUserIsAnotherStudent_ThrowsForbiddenAccessException()
+    {
+        var currentUser = new FakeCurrentUserService(Guid.NewGuid(), isAuthenticated: true);
+
+        var action = () => CurrentUserAuthorizationGuard.EnsureStudentSelfOrAdmin(currentUser, Guid.NewGuid());
+
+        action.Should().Throw<ForbiddenAccessException>();
+    }
+
+    [Fact]
+    public async Task EnsureEnrollmentReadAccessAsync_WhenCurrentUserIsEnrollmentOwner_DoesNotThrow()
+    {
+        var studentId = Guid.NewGuid();
+        var currentUser = new FakeCurrentUserService(studentId, isAuthenticated: true);
+        var repository = new FakeCourseRepository(course: null);
+
+        var action = async () => await CurrentUserAuthorizationGuard.EnsureEnrollmentReadAccessAsync(
+            currentUser,
+            studentId,
+            Guid.NewGuid(),
+            repository,
+            CancellationToken.None);
+
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task EnsureEnrollmentReadAccessAsync_WhenCurrentUserIsAdmin_DoesNotThrow()
+    {
+        var currentUser = new FakeCurrentUserService(Guid.NewGuid(), isAuthenticated: true, roles: ["Admin"]);
+        var repository = new FakeCourseRepository(course: null);
+
+        var action = async () => await CurrentUserAuthorizationGuard.EnsureEnrollmentReadAccessAsync(
+            currentUser,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            repository,
+            CancellationToken.None);
+
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task EnsureEnrollmentReadAccessAsync_WhenCurrentUserIsCourseInstructor_DoesNotThrow()
+    {
+        var instructorId = Guid.NewGuid();
+        var currentUser = new FakeCurrentUserService(instructorId, isAuthenticated: true);
+        var course = CreateCourse(instructorId);
+        var repository = new FakeCourseRepository(course);
+
+        var action = async () => await CurrentUserAuthorizationGuard.EnsureEnrollmentReadAccessAsync(
+            currentUser,
+            Guid.NewGuid(),
+            course.Id,
+            repository,
+            CancellationToken.None);
+
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task EnsureEnrollmentReadAccessAsync_WhenCurrentUserIsNotOwnerAdminOrInstructor_ThrowsForbiddenAccessException()
+    {
+        var currentUser = new FakeCurrentUserService(Guid.NewGuid(), isAuthenticated: true);
+        var course = CreateCourse(Guid.NewGuid());
+        var repository = new FakeCourseRepository(course);
+
+        var action = async () => await CurrentUserAuthorizationGuard.EnsureEnrollmentReadAccessAsync(
+            currentUser,
+            Guid.NewGuid(),
+            course.Id,
+            repository,
+            CancellationToken.None);
+
+        await action.Should().ThrowAsync<ForbiddenAccessException>();
+    }
+
+    [Fact]
+    public async Task EnsureEnrollmentReadAccessAsync_WhenCourseDoesNotExist_ThrowsNotFoundException()
+    {
+        var currentUser = new FakeCurrentUserService(Guid.NewGuid(), isAuthenticated: true);
+        var repository = new FakeCourseRepository(course: null);
+
+        var action = async () => await CurrentUserAuthorizationGuard.EnsureEnrollmentReadAccessAsync(
+            currentUser,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            repository,
+            CancellationToken.None);
+
+        await action.Should().ThrowAsync<NotFoundException>();
+    }
+
+    private static Course CreateCourse(Guid instructorId)
+    {
+        return new Course(
+            "Security Test Course",
+            "Course used for guard tests.",
+            instructorId,
+            CourseCategory.Programming,
+            CourseLevel.Beginner,
+            Duration.Create(1, 0),
+            0m);
+    }
+
+    private sealed class FakeCurrentUserService(Guid? userId, bool isAuthenticated, IEnumerable<string>? roles = null)
+        : ICurrentUserService
+    {
+        private readonly HashSet<string> _roles = new(roles ?? [], StringComparer.OrdinalIgnoreCase);
+
+        public Guid? UserId { get; } = userId;
+
+        public string? UserEmail => "security-tests@local";
+
+        public bool IsAuthenticated { get; } = isAuthenticated;
+
+        public bool IsInRole(string role) => _roles.Contains(role);
+    }
+
+    private sealed class FakeCourseRepository(Course? course) : ICourseRepository
+    {
+        public Task<Course?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            if (course is null || course.Id != id)
+                return Task.FromResult<Course?>(null);
+
+            return Task.FromResult<Course?>(course);
+        }
+
+        public Task<IReadOnlyList<Course>> ListAllAsync(CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task AddAsync(Course entity, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task UpdateAsync(Course entity, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task DeleteAsync(Course entity, CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<Course>> GetByInstructorIdAsync(Guid instructorId, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<Course>> GetByCategoryAsync(CourseCategory category, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<Course>> GetFeaturedCoursesAsync(int count, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<Course>> SearchCoursesAsync(string? searchTerm, PaginationParameters pagination, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<Course>> GetRecentCoursesAsync(int count, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<Course>> GetByLevelAsync(CourseLevel level, CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+
+        public Task<int> GetCoursesCountAsync(CancellationToken cancellationToken) =>
+            throw new NotImplementedException();
+    }
+}

--- a/ELearning.Application/Common/Security/CurrentUserAuthorizationGuard.cs
+++ b/ELearning.Application/Common/Security/CurrentUserAuthorizationGuard.cs
@@ -1,0 +1,43 @@
+using ELearning.Application.Common.Exceptions;
+using ELearning.Application.Common.Interfaces;
+using ELearning.Domain.Entities.CourseAggregate.Abstractions.Repositories;
+
+namespace ELearning.Application.Common.Security;
+
+public static class CurrentUserAuthorizationGuard
+{
+    public static void EnsureAuthenticated(ICurrentUserService currentUserService)
+    {
+        if (!currentUserService.IsAuthenticated || currentUserService.UserId is null)
+            throw new ForbiddenAccessException();
+    }
+
+    public static void EnsureStudentSelfOrAdmin(ICurrentUserService currentUserService, Guid requestedStudentId)
+    {
+        EnsureAuthenticated(currentUserService);
+
+        var currentUserId = currentUserService.UserId!.Value;
+        if (currentUserId != requestedStudentId && !currentUserService.IsInRole("Admin"))
+            throw new ForbiddenAccessException();
+    }
+
+    public static async Task EnsureEnrollmentReadAccessAsync(
+        ICurrentUserService currentUserService,
+        Guid studentId,
+        Guid courseId,
+        ICourseRepository courseRepository,
+        CancellationToken cancellationToken)
+    {
+        EnsureAuthenticated(currentUserService);
+
+        var currentUserId = currentUserService.UserId!.Value;
+        if (currentUserId == studentId || currentUserService.IsInRole("Admin"))
+            return;
+
+        var course = await courseRepository.GetByIdAsync(courseId, cancellationToken)
+            ?? throw new NotFoundException("Course", courseId);
+
+        if (course.InstructorId != currentUserId)
+            throw new ForbiddenAccessException();
+    }
+}

--- a/ELearning.Application/Enrollments/Handlers/GetEnrollmentDetailQueryHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/GetEnrollmentDetailQueryHandler.cs
@@ -1,7 +1,9 @@
 using AutoMapper;
 using ELearning.Application.Common.Exceptions;
+using ELearning.Application.Common.Interfaces;
 using ELearning.Application.Common.Model;
 using ELearning.Application.Common.Resilience;
+using ELearning.Application.Common.Security;
 using ELearning.Application.Enrollments.Abstractions.ReadModels;
 using ELearning.Application.Enrollments.Dtos;
 using ELearning.Application.Enrollments.Queries;
@@ -21,15 +23,24 @@ public class GetEnrollmentDetailQueryHandler(
         IStudentRepository studentRepository,
         IProgressRepository progressRepository,
         ILessonRepository lessonRepository,
+        ICurrentUserService currentUserService,
         IMapper mapper)
     : IRequestHandler<GetEnrollmentDetailQuery, Result<EnrollmentDetailDto>>
 {
     public async Task<Result<EnrollmentDetailDto>> Handle(GetEnrollmentDetailQuery request, CancellationToken cancellationToken)
     {
+        CurrentUserAuthorizationGuard.EnsureAuthenticated(currentUserService);
+
         try
         {
             // Try Dapr read service first
             var enrollmentDto = await enrollmentReadService.GetByIdAsync(request.EnrollmentId, cancellationToken);
+            await CurrentUserAuthorizationGuard.EnsureEnrollmentReadAccessAsync(
+                currentUserService,
+                enrollmentDto.StudentId,
+                enrollmentDto.CourseId,
+                courseRepository,
+                cancellationToken);
             return Result.Success(enrollmentDto);
         }
         catch (Exception ex) when (ReadModelFallbackPolicy.ShouldFallback(ex, cancellationToken))
@@ -37,6 +48,12 @@ public class GetEnrollmentDetailQueryHandler(
             // Fall back to repository
             var enrollment = await enrollmentRepository.GetByIdAsync(request.EnrollmentId, cancellationToken) ??
                 throw new NotFoundException(nameof(Enrollment), request.EnrollmentId);
+            await CurrentUserAuthorizationGuard.EnsureEnrollmentReadAccessAsync(
+                currentUserService,
+                enrollment.StudentId,
+                enrollment.CourseId,
+                courseRepository,
+                cancellationToken);
 
             var course = await courseRepository.GetByIdAsync(enrollment.CourseId, cancellationToken)
                 ?? throw new NotFoundException("Course", enrollment.CourseId);

--- a/ELearning.Application/Students/Handlers/GetStudentEnrollmentsQueryHandler.cs
+++ b/ELearning.Application/Students/Handlers/GetStudentEnrollmentsQueryHandler.cs
@@ -1,6 +1,8 @@
 using ELearning.Application.Common.Exceptions;
+using ELearning.Application.Common.Interfaces;
 using ELearning.Application.Common.Model;
 using ELearning.Application.Common.Resilience;
+using ELearning.Application.Common.Security;
 using ELearning.Application.Enrollments.Abstractions.ReadModels;
 using ELearning.Application.Enrollments.Dtos;
 using ELearning.Application.Students.Abstractions.ReadModels;
@@ -17,11 +19,14 @@ public class GetStudentEnrollmentsQueryHandler(
         IEnrollmentReadRepository enrollmentReadRepository,
         ICourseRepository courseRepository,
         IStudentReadService studentReadService,
-        IProgressRepository progressRepository)
+        IProgressRepository progressRepository,
+        ICurrentUserService currentUserService)
     : IRequestHandler<GetStudentEnrollmentsQuery, Result<PaginatedList<EnrollmentDto>>>
 {
     public async Task<Result<PaginatedList<EnrollmentDto>>> Handle(GetStudentEnrollmentsQuery request, CancellationToken cancellationToken)
     {
+        CurrentUserAuthorizationGuard.EnsureStudentSelfOrAdmin(currentUserService, request.StudentId);
+
         try
         {
             // Try Dapr read service first

--- a/ELearning.Application/Students/Handlers/GetStudentProgressQueryHandler.cs
+++ b/ELearning.Application/Students/Handlers/GetStudentProgressQueryHandler.cs
@@ -1,6 +1,8 @@
 using ELearning.Application.Common.Exceptions;
+using ELearning.Application.Common.Interfaces;
 using ELearning.Application.Common.Model;
 using ELearning.Application.Common.Resilience;
+using ELearning.Application.Common.Security;
 using ELearning.Application.Enrollments.Abstractions.ReadModels;
 using ELearning.Application.Students.Abstractions.ReadModels;
 using ELearning.Application.Students.Dtos;
@@ -19,11 +21,14 @@ public class GetStudentProgressQueryHandler(
         IStudentRepository studentRepository,
         IEnrollmentReadRepository enrollmentReadRepository,
         IProgressRepository progressRepository,
-        ICourseRepository courseRepository)
+        ICourseRepository courseRepository,
+        ICurrentUserService currentUserService)
     : IRequestHandler<GetStudentProgressQuery, Result<StudentProgressDto>>
 {
     public async Task<Result<StudentProgressDto>> Handle(GetStudentProgressQuery request, CancellationToken cancellationToken)
     {
+        CurrentUserAuthorizationGuard.EnsureStudentSelfOrAdmin(currentUserService, request.StudentId);
+
         try
         {
             // Try to get from Dapr read service first

--- a/ELearning.Infrastructure/Data/ApplicationDbContext.cs
+++ b/ELearning.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,22 +1,27 @@
-﻿using ELearning.Domain.Entities.CourseAggregate;
+using ELearning.Domain.Entities.CourseAggregate;
 using ELearning.Domain.Entities.EnrollmentAggregate;
 using ELearning.Domain.Entities.UserAggregate;
 using ELearning.SharedKernel;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace ELearning.Infrastructure.Data;
 
 public class ApplicationDbContext : DbContext
 {
+    private readonly IPublisher? _publisher;
+
     //private readonly ICurrentUserService _currentUserService;
     //private readonly IDateTime _dateTime;
 
     public ApplicationDbContext(
-        DbContextOptions<ApplicationDbContext> options//,
-                                                      //ICurrentUserService currentUserService,
-                                                      //IDateTime dateTime
+        DbContextOptions<ApplicationDbContext> options,
+        IPublisher? publisher = null//,
+                              //ICurrentUserService currentUserService,
+                              //IDateTime dateTime
         ) : base(options)
     {
+        _publisher = publisher;
         //_currentUserService = currentUserService;
         //_dateTime = dateTime;
     }
@@ -50,8 +55,8 @@ public class ApplicationDbContext : DbContext
 
         var result = await base.SaveChangesAsync(cancellationToken);
 
-        // Dispatch domain events after saving changes
-        await DispatchDomainEvents();
+        // Dispatch domain events after saving changes.
+        await DispatchDomainEvents(cancellationToken);
 
         return result;
     }
@@ -63,7 +68,7 @@ public class ApplicationDbContext : DbContext
         base.OnModelCreating(modelBuilder);
     }
 
-    private async Task DispatchDomainEvents()
+    private async Task DispatchDomainEvents(CancellationToken cancellationToken)
     {
         var domainEntities = ChangeTracker
             .Entries<BaseEntity>()
@@ -75,13 +80,17 @@ public class ApplicationDbContext : DbContext
             .SelectMany(x => x.DomainEvents)
             .ToList();
 
-        domainEntities.ForEach(entity => entity.ClearDomainEvents());
+        if (_publisher is null)
+        {
+            domainEntities.ForEach(entity => entity.ClearDomainEvents());
+            return;
+        }
 
         foreach (var domainEvent in domainEvents)
         {
-            // In a real application, you would dispatch these events
-            // using a mediator or an event bus
-            // await _mediator.Publish(domainEvent);
+            await _publisher.Publish(domainEvent, cancellationToken);
         }
+
+        domainEntities.ForEach(entity => entity.ClearDomainEvents());
     }
 }

--- a/ELearning.IntegrationTests/AuthAndAuthorizationIntegrationTests.cs
+++ b/ELearning.IntegrationTests/AuthAndAuthorizationIntegrationTests.cs
@@ -1,0 +1,135 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using ELearning.Domain.Entities.UserAggregate;
+using ELearning.Domain.ValueObjects;
+using ELearning.Infrastructure.Data;
+using ELearning.IntegrationTests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace ELearning.IntegrationTests;
+
+public sealed class AuthAndAuthorizationIntegrationTests : IClassFixture<RealAuthWebApplicationFactory>
+{
+    private const string JwtIssuer = "integration-tests";
+    private const string JwtAudience = "integration-tests";
+    private const string JwtSecret = "integration-tests-secret-key-with-32chars";
+
+    private readonly RealAuthWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public AuthAndAuthorizationIntegrationTests(RealAuthWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Login_WithRealAuthService_ReturnsJwtToken()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var email = $"auth.login.{Guid.NewGuid():N}@tests.io";
+        const string password = "P@ssword123!";
+
+        await SeedStudentAsync(email, password, cancellationToken);
+
+        var response = await _client.PostAsJsonAsync("/api/auth/login", new
+        {
+            Email = email,
+            Password = password
+        }, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var content = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken);
+        Assert.True(content.RootElement.GetProperty("succeeded").GetBoolean());
+
+        var authResult = content.RootElement.GetProperty("data");
+        Assert.True(authResult.GetProperty("success").GetBoolean());
+        var token = authResult.GetProperty("token").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(token));
+        Assert.NotEqual("stub-token", token);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithoutToken_ReturnsUnauthorized()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync($"/api/students/{Guid.NewGuid()}/progress", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InstructorEndpoint_WithStudentToken_ReturnsForbidden()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var studentId = Guid.NewGuid();
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/api/instructors/{Guid.NewGuid()}/pending-submissions");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt(studentId, "Student"));
+
+        var response = await _client.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task StudentProgress_WithAnotherStudentToken_ReturnsForbidden()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var tokenOwnerId = Guid.NewGuid();
+        var requestedStudentId = Guid.NewGuid();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/api/students/{requestedStudentId}/progress");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt(tokenOwnerId, "Student"));
+
+        var response = await _client.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    private async Task<Guid> SeedStudentAsync(string email, string password, CancellationToken cancellationToken)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var userService = scope.ServiceProvider.GetRequiredService<ELearning.Domain.Entities.UserAggregate.Abstractions.Services.IUserService>();
+
+        var student = new Student(
+            firstName: "Integration",
+            lastName: "Student",
+            email: Email.Create(email),
+            passwordHash: userService.HashPassword(password));
+
+        dbContext.Students.Add(student);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return student.Id;
+    }
+
+    private static string CreateJwt(Guid userId, string role)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+            new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new Claim(ClaimTypes.Role, role),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: JwtIssuer,
+            audience: JwtAudience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/ELearning.IntegrationTests/DatabaseInitializerTests.cs
+++ b/ELearning.IntegrationTests/DatabaseInitializerTests.cs
@@ -1,0 +1,48 @@
+using ELearning.API.Infrastructure;
+using ELearning.Infrastructure;
+using ELearning.Infrastructure.Data;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ELearning.IntegrationTests;
+
+public sealed class DatabaseInitializerTests
+{
+    [Theory]
+    [InlineData("SqlServer", true)]
+    [InlineData("sqlserver", true)]
+    [InlineData("SqliteInMemory", false)]
+    [InlineData("UnknownProvider", false)]
+    [InlineData(null, false)]
+    public void ShouldApplyMigrations_UsesExpectedStrategy(string? provider, bool expected)
+    {
+        var result = DatabaseInitializer.ShouldApplyMigrations(provider);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithSqliteInMemoryProvider_CreatesDatabase()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Provider"] = "SqliteInMemory",
+                ["Database:SqliteInMemoryConnection"] = "Data Source=:memory:;Cache=Shared"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddInfrastructure(configuration);
+        var serviceProvider = services.BuildServiceProvider();
+
+        await DatabaseInitializer.InitializeAsync(serviceProvider, configuration, cancellationToken);
+
+        using var scope = serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var canConnect = await dbContext.Database.CanConnectAsync(cancellationToken);
+        Assert.True(canConnect);
+    }
+}

--- a/ELearning.IntegrationTests/DomainEventsDispatchTests.cs
+++ b/ELearning.IntegrationTests/DomainEventsDispatchTests.cs
@@ -1,0 +1,100 @@
+using ELearning.Domain.Entities.CourseAggregate;
+using ELearning.Domain.Entities.CourseAggregate.Events;
+using ELearning.Domain.Entities.CourseAggregate.Enums;
+using ELearning.Domain.Entities.UserAggregate;
+using ELearning.Domain.ValueObjects;
+using ELearning.Infrastructure.Data;
+using MediatR;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace ELearning.IntegrationTests;
+
+public sealed class DomainEventsDispatchTests
+{
+    [Fact]
+    public async Task SaveChangesAsync_WithPublisher_PublishesAndClearsDomainEvents()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(cancellationToken);
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var publisher = new RecordingPublisher();
+        await using var dbContext = new ApplicationDbContext(options, publisher);
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+
+        var instructor = CreateInstructor();
+        dbContext.Instructors.Add(instructor);
+        var course = CreateCourse(instructor.Id);
+        dbContext.Courses.Add(course);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        Assert.Single(publisher.PublishedNotifications);
+        Assert.IsType<CourseCreatedEvent>(publisher.PublishedNotifications[0]);
+        Assert.Empty(course.DomainEvents);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_WithoutPublisher_ClearsDomainEvents()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(cancellationToken);
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var dbContext = new ApplicationDbContext(options, publisher: null);
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+
+        var instructor = CreateInstructor();
+        dbContext.Instructors.Add(instructor);
+        var course = CreateCourse(instructor.Id);
+        dbContext.Courses.Add(course);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        Assert.Empty(course.DomainEvents);
+    }
+
+    private static Course CreateCourse(Guid instructorId) =>
+        new(
+            "Domain Event Test Course",
+            "Tests domain event dispatch from ApplicationDbContext.",
+            instructorId,
+            CourseCategory.Programming,
+            CourseLevel.Beginner,
+            Duration.Create(1, 0),
+            0m);
+
+    private static Instructor CreateInstructor() =>
+        new(
+            "Domain",
+            "Publisher",
+            Email.Create("domain.publisher@tests.io"),
+            "hashed-password");
+
+    private sealed class RecordingPublisher : IPublisher
+    {
+        public List<object> PublishedNotifications { get; } = [];
+
+        public Task Publish(object notification, CancellationToken cancellationToken = default)
+        {
+            PublishedNotifications.Add(notification);
+            return Task.CompletedTask;
+        }
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+        {
+            PublishedNotifications.Add(notification!);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/ELearning.IntegrationTests/Infrastructure/RealAuthWebApplicationFactory.cs
+++ b/ELearning.IntegrationTests/Infrastructure/RealAuthWebApplicationFactory.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace ELearning.IntegrationTests.Infrastructure;
+
+public sealed class RealAuthWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            var testSettings = new Dictionary<string, string?>
+            {
+                ["Database:Provider"] = "SqliteInMemory",
+                ["Database:SqliteInMemoryConnection"] = "Data Source=:memory:;Cache=Shared",
+                ["JwtSettings:Issuer"] = "integration-tests",
+                ["JwtSettings:Audience"] = "integration-tests",
+                ["JwtSettings:Secret"] = "integration-tests-secret-key-with-32chars",
+                ["JwtSettings:ExpiryInDays"] = "7",
+                ["Ocelot:Enabled"] = "false"
+            };
+
+            configBuilder.AddInMemoryCollection(testSettings);
+        });
+    }
+}

--- a/ELearning.IntegrationTests/OcelotGatewayModeTests.cs
+++ b/ELearning.IntegrationTests/OcelotGatewayModeTests.cs
@@ -1,0 +1,36 @@
+using ELearning.API.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace ELearning.IntegrationTests;
+
+public sealed class OcelotGatewayModeTests
+{
+    [Fact]
+    public void IsEnabled_WhenFlagMissing_ReturnsFalse()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var enabled = OcelotGatewayMode.IsEnabled(configuration);
+
+        Assert.False(enabled);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void IsEnabled_WhenFlagProvided_ResolvesValue(string rawValue, bool expected)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Ocelot:Enabled"] = rawValue
+            })
+            .Build();
+
+        var enabled = OcelotGatewayMode.IsEnabled(configuration);
+
+        Assert.Equal(expected, enabled);
+    }
+}

--- a/ELearning.SharedKernel/Abstractions/IDomainEvent.cs
+++ b/ELearning.SharedKernel/Abstractions/IDomainEvent.cs
@@ -1,6 +1,8 @@
-﻿namespace ELearning.SharedKernel.Abstractions;
+using MediatR;
 
-public interface IDomainEvent
+namespace ELearning.SharedKernel.Abstractions;
+
+public interface IDomainEvent : INotification
 {
     DateTime OccurredOnUTC { get; }
 }

--- a/ELearning.SharedKernel/ELearning.SharedKernel.csproj
+++ b/ELearning.SharedKernel/ELearning.SharedKernel.csproj
@@ -1,4 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
+  </ItemGroup>
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/README.md
+++ b/README.md
@@ -1,138 +1,113 @@
 # E-Learning Platform API
 
-Production-style backend sample built with .NET 10, Clean Architecture, CQRS, and Domain-Driven Design (DDD).
+Monolith backend sample built with .NET 10 using Clean Architecture, CQRS, and DDD-style domain modeling.
 
-This repository is intended as **sample code for engineering interviews and job applications**.
+This repository is curated as portfolio code for senior/backend engineering interviews.
 
-## Why This Project Is a Strong Sample
+## What This Demonstrates
 
-- Clear layer separation (API, Application, Domain, Infrastructure)
-- DDD-focused domain model with aggregates and value objects
-- Aggregate-root transaction boundary enforcement (no child-entity write repositories)
-- CQRS with MediatR and validation pipeline
-- Unit of Work + transaction behavior for command consistency
-- Warning-clean build and passing test suite
+- Clean layer boundaries across API, Application, Domain, Infrastructure, SharedKernel
+- Command/query separation with MediatR pipeline behaviors
+- Aggregate-focused domain model with value objects and invariants
+- Consistent API envelope responses for REST and a secondary GraphQL surface
+- Integration point pattern for external read models (Dapr-style fallback)
 
-## Tech Stack
-
-- .NET 10
-- ASP.NET Core Web API
-- MediatR
-- FluentValidation
-- EF Core (SQL Server)
-- GraphQL (secondary API surface)
-- Dapr (read-model integrations)
-- xUnit v3
-
-## Solution Structure
+## Architecture (Monolith + Clean Architecture)
 
 ```text
-ELearning.API                # REST-first host (Swagger), plus GraphQL endpoint
-ELearning.Application        # Commands/queries, handlers, DTOs, behaviors, interfaces
-ELearning.Domain             # Aggregates, entities, value objects, domain rules/events
-ELearning.Infrastructure     # EF repositories, read-model services, external implementations
-ELearning.Persistence        # Persistence project
-ELearning.SharedKernel       # Shared abstractions and base types
-ELearning.Application.Tests  # Application/unit validation tests
-ELearning.IntegrationTests   # API integration tests (WebApplicationFactory)
+ELearning.API                # Web host, REST controllers, GraphQL schema/resolvers
+ELearning.Application        # Use cases (commands/queries), handlers, DTOs, behaviors
+ELearning.Domain             # Aggregates, entities, value objects, domain rules
+ELearning.Infrastructure     # EF Core, repositories, auth, read-model services, gateways
+ELearning.Persistence        # Persistence project boundary
+ELearning.SharedKernel       # Cross-cutting abstractions/base types
+ELearning.Application.Tests  # Application validation/unit tests
+ELearning.IntegrationTests   # API integration tests
 ```
 
-## Architecture and DDD Notes
-
-### Clean Architecture dependency direction
+Dependency direction (intended):
 
 - API -> Application
 - Infrastructure -> Application + Domain
 - Application -> Domain + SharedKernel
 - Domain -> SharedKernel
 
-### DDD boundaries
+## Domain Scope
 
-- Value objects (`Email`, `Duration`, `Rating`) are not persisted independently and have no repositories.
-- Minimum transactional consistency is enforced at aggregate-root level.
-- Command writes are coordinated through Unit of Work.
-- Child entities are accessed for reads only; write orchestration happens through root aggregates.
+Primary business flows currently implemented:
 
-## Key Functional Areas
+- Authentication and role-based access (Student, Instructor, Admin)
+- Course lifecycle (create/update/delete/list/filter)
+- Enrollment lifecycle and student progress access
+- Assignment submission and instructor grading
+- Instructor pending-submissions workflow
 
-- Authentication (`/api/auth/*`)
-- Course and instructor flows
-- Enrollment lifecycle
-- Submission creation and grading
-- Student progress reporting
+## Tech Stack
 
-## Configuration
+- .NET 10 / ASP.NET Core
+- EF Core (Sqlite in-memory by default, SQL Server configurable)
+- MediatR + FluentValidation
+- HotChocolate GraphQL
+- Swagger/OpenAPI
+- Ocelot (gateway config present)
+- xUnit v3
 
-Main configuration files:
+## Local Run (Quick Start)
 
-- `ELearning.API/appsettings.json`
-- `ELearning.API/appsettings.Development.json`
+1. Configure required settings (at minimum JWT values):
 
-Important settings:
+```powershell
+dotnet user-secrets set "JwtSettings:Issuer" "elearning-local" --project ELearning.API/ELearning.API.csproj
+dotnet user-secrets set "JwtSettings:Audience" "elearning-local" --project ELearning.API/ELearning.API.csproj
+dotnet user-secrets set "JwtSettings:Secret" "your-long-random-secret-at-least-32-characters" --project ELearning.API/ELearning.API.csproj
+dotnet user-secrets set "JwtSettings:ExpiryInDays" "7" --project ELearning.API/ELearning.API.csproj
+```
 
-- `ConnectionStrings:DefaultConnection`
-- `JwtSettings:Issuer`
-- `JwtSettings:Audience`
-- `JwtSettings:Secret`
-- `JwtSettings:ExpiryInDays`
-- `Dapr:HttpPort`
-- `Dapr:GrpcPort`
-
-## Run
+2. Run API:
 
 ```powershell
 dotnet run --project ELearning.API/ELearning.API.csproj
 ```
 
-Endpoints:
+3. Open endpoints:
 
-- REST docs (Swagger UI): `/`
-- OpenAPI JSON: `/swagger/v1/swagger.json`
-- REST (versioned): `/api/v1/*`
+- Swagger UI: `/`
+- REST: `/api/v1/*` (also `/api/*` compatibility routes)
 - GraphQL: `/graphql`
 
 ## Build and Test
 
-Build:
-
 ```powershell
 dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false
-```
-
-Run all tests:
-
-```powershell
 dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
 ```
 
-Run only application tests:
+Current test status from latest local run:
 
-```powershell
-dotnet test ELearning.Application.Tests/ELearning.Application.Tests.csproj -nologo /p:UseSharedCompilation=false
-```
+- `ELearning.Application.Tests`: 71 passed
+- `ELearning.IntegrationTests`: 1 passed
 
-Run only integration tests:
+## API Notes
 
-```powershell
-dotnet test ELearning.IntegrationTests/ELearning.IntegrationTests.csproj -nologo /p:UseSharedCompilation=false
-```
+- REST is the primary interface for this sample.
+- GraphQL is intentionally secondary and reuses the same Application use cases.
+- Responses use a consistent envelope (`succeeded`, `data`, `error`) for REST.
 
-## Testing Approach
+## Why This Is A Strong Portfolio Monolith
 
-- `ELearning.Application.Tests`: DTO and validation-focused tests with shared helpers/factories.
-- `ELearning.IntegrationTests`: API-level tests with controlled service replacement via `WebApplicationFactory`.
+- Business logic is centered in Application + Domain, not controllers.
+- Request validation and transaction handling are centralized via MediatR behaviors.
+- The codebase shows clear seams for scaling later (read services, facades, abstractions).
+- Test projects are separated by responsibility (application-level vs integration-level).
 
-## Next Steps
+## Roadmap (High-Impact Next Additions)
 
-- Add an **Application Facade** layer for complex use-case orchestration (single entrypoints for API/GraphQL).
-- Add dedicated **read-model repositories/interfaces** for all query-heavy modules (courses, submissions, instructors, students) to fully standardize CQRS read paths.
-- Remove remaining child-entity repository abstractions from Domain and keep only aggregate-root write repositories.
-- Introduce **architecture tests** (layer dependency tests) to enforce Clean Architecture rules in CI.
-- Expand integration tests to cover enrollment and submission workflows end-to-end.
-- Add domain-focused unit tests for aggregate invariants (`Course`, `Enrollment`, `User`).
-- Add optimistic concurrency handling (row version / concurrency tokens) for high-contention aggregates.
-- Add API versioning strategy docs and backward-compatibility contract tests.
-- Add CI quality gates: formatting, analyzers, build, tests, and optional coverage threshold.
+- Add global exception-to-problem-details mapping middleware.
+- Add architecture tests enforcing layer dependency rules in CI.
+- Increase integration coverage to enrollment/submission end-to-end scenarios.
+- Add optimistic concurrency (row version tokens) for write-heavy aggregates.
+- Add migration-based database bootstrapping for production safety.
+- Expand auth story with refresh tokens/revocation and audit events.
 
 ## License
 


### PR DESCRIPTION
This PR hardens production-readiness and closes key architecture/testing gaps across startup, middleware pipeline, domain events, and integration coverage.

**Commits included**
- `refactor(startup): replace direct EnsureCreated with provider-aware DatabaseInitializer and add integration tests`
- `feat(startup): add optional Ocelot gateway mode and align pipeline with monolith defaults`
- `feat(domain-events): publish domain events via MediatR from DbContext and add dispatch integration tests`
- `test(integration): add real-auth and JWT authorization coverage for protected API endpoints`

**What changed**

1. Database initialization strategy
- Replaced direct `EnsureCreated` call in startup with `DatabaseInitializer`.
- `SqlServer` provider now uses `MigrateAsync`.
- Non-SqlServer providers keep `EnsureCreatedAsync` behavior (keeps sqlite in-memory workflows stable).
- Added integration tests for strategy selection and sqlite initialization.

2. Ocelot gateway mode
- Added explicit `Ocelot:Enabled` switch.
- Monolith mode (`false`, default): maps local REST/GraphQL endpoints.
- Gateway mode (`true`): runs Ocelot middleware pipeline.
- Added tests for gateway mode flag resolution.
- Added default config in `appsettings.json` and `appsettings.Development.json`.

3. Domain event dispatch
- `IDomainEvent` now integrates with MediatR notification contracts.
- `ApplicationDbContext` now publishes collected domain events via `IPublisher` after successful save.
- Domain events are cleared after publish, and also cleared in no-publisher fallback path.
- Added integration tests validating dispatch + clear behavior.

4. Integration test coverage (auth/authorization)
- Added real-auth test factory that does not replace `IAuthService`.
- Added end-to-end integration tests for:
  - login with real auth service returns real JWT
  - unauthorized access returns `401`
  - role-protected access returns `403` for wrong role
  - ownership-protected access returns `403` for horizontal access attempts

**Why**
- Avoids migration bypass in startup for SQL Server deployments.
- Makes Ocelot setup intentional instead of partially configured.
- Completes domain event flow so events are not silently dropped.
- Increases confidence in auth and authorization behavior through realistic integration tests.

**Validation**
- `dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false`
- All tests passing:
  - `ELearning.Application.Tests`: 80 passed
  - `ELearning.IntegrationTests`: 16 passed