### PR TITLE
Standardize Test Assertions with FluentAssertions

### DIFF
--- a/ELearning.IntegrationTests/AuthAndAuthorizationIntegrationTests.cs
+++ b/ELearning.IntegrationTests/AuthAndAuthorizationIntegrationTests.cs
@@ -9,6 +9,7 @@ using ELearning.Domain.Entities.UserAggregate;
 using ELearning.Domain.ValueObjects;
 using ELearning.Infrastructure.Data;
 using ELearning.IntegrationTests.Infrastructure;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 
@@ -44,17 +45,17 @@ public sealed class AuthAndAuthorizationIntegrationTests : IClassFixture<RealAut
             Password = password
         }, cancellationToken);
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
         using var content = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken);
-        Assert.True(content.RootElement.GetProperty("succeeded").GetBoolean());
+        content.RootElement.GetProperty("succeeded").GetBoolean().Should().BeTrue();
 
         var authResult = content.RootElement.GetProperty("data");
-        Assert.True(authResult.GetProperty("success").GetBoolean());
+        authResult.GetProperty("success").GetBoolean().Should().BeTrue();
         var token = authResult.GetProperty("token").GetString();
-        Assert.False(string.IsNullOrWhiteSpace(token));
-        Assert.NotEqual("stub-token", token);
+        token.Should().NotBeNullOrWhiteSpace();
+        token.Should().NotBe("stub-token");
     }
 
     [Fact]
@@ -63,7 +64,7 @@ public sealed class AuthAndAuthorizationIntegrationTests : IClassFixture<RealAut
         var cancellationToken = TestContext.Current.CancellationToken;
         var response = await _client.GetAsync($"/api/students/{Guid.NewGuid()}/progress", cancellationToken);
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Fact]
@@ -76,7 +77,7 @@ public sealed class AuthAndAuthorizationIntegrationTests : IClassFixture<RealAut
 
         var response = await _client.SendAsync(request, cancellationToken);
 
-        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]
@@ -91,7 +92,7 @@ public sealed class AuthAndAuthorizationIntegrationTests : IClassFixture<RealAut
 
         var response = await _client.SendAsync(request, cancellationToken);
 
-        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     private async Task<Guid> SeedStudentAsync(string email, string password, CancellationToken cancellationToken)

--- a/ELearning.IntegrationTests/AuthControllerIntegrationTests.cs
+++ b/ELearning.IntegrationTests/AuthControllerIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using ELearning.IntegrationTests.Infrastructure;
+using FluentAssertions;
 
 namespace ELearning.IntegrationTests;
 
@@ -27,15 +28,15 @@ public sealed class AuthControllerIntegrationTests : IClassFixture<TestWebApplic
 
         var response = await _client.PostAsJsonAsync("/api/auth/login", request, cancellationToken);
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
         using var content = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken);
-        Assert.True(content.RootElement.GetProperty("succeeded").GetBoolean());
+        content.RootElement.GetProperty("succeeded").GetBoolean().Should().BeTrue();
 
         var authResult = content.RootElement.GetProperty("data");
-        Assert.True(authResult.GetProperty("success").GetBoolean());
-        Assert.Equal("stub-token", authResult.GetProperty("token").GetString());
-        Assert.Equal("sample.user@elearning.test", authResult.GetProperty("email").GetString());
+        authResult.GetProperty("success").GetBoolean().Should().BeTrue();
+        authResult.GetProperty("token").GetString().Should().Be("stub-token");
+        authResult.GetProperty("email").GetString().Should().Be("sample.user@elearning.test");
     }
 }

--- a/ELearning.IntegrationTests/DatabaseInitializerTests.cs
+++ b/ELearning.IntegrationTests/DatabaseInitializerTests.cs
@@ -1,6 +1,7 @@
 using ELearning.API.Infrastructure;
 using ELearning.Infrastructure;
 using ELearning.Infrastructure.Data;
+using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,7 +19,7 @@ public sealed class DatabaseInitializerTests
     {
         var result = DatabaseInitializer.ShouldApplyMigrations(provider);
 
-        Assert.Equal(expected, result);
+        result.Should().Be(expected);
     }
 
     [Fact]
@@ -43,6 +44,6 @@ public sealed class DatabaseInitializerTests
         using var scope = serviceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         var canConnect = await dbContext.Database.CanConnectAsync(cancellationToken);
-        Assert.True(canConnect);
+        canConnect.Should().BeTrue();
     }
 }

--- a/ELearning.IntegrationTests/DomainEventsDispatchTests.cs
+++ b/ELearning.IntegrationTests/DomainEventsDispatchTests.cs
@@ -4,6 +4,7 @@ using ELearning.Domain.Entities.CourseAggregate.Enums;
 using ELearning.Domain.Entities.UserAggregate;
 using ELearning.Domain.ValueObjects;
 using ELearning.Infrastructure.Data;
+using FluentAssertions;
 using MediatR;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -34,9 +35,9 @@ public sealed class DomainEventsDispatchTests
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        Assert.Single(publisher.PublishedNotifications);
-        Assert.IsType<CourseCreatedEvent>(publisher.PublishedNotifications[0]);
-        Assert.Empty(course.DomainEvents);
+        publisher.PublishedNotifications.Should().ContainSingle()
+            .Which.Should().BeOfType<CourseCreatedEvent>();
+        course.DomainEvents.Should().BeEmpty();
     }
 
     [Fact]
@@ -60,7 +61,7 @@ public sealed class DomainEventsDispatchTests
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        Assert.Empty(course.DomainEvents);
+        course.DomainEvents.Should().BeEmpty();
     }
 
     private static Course CreateCourse(Guid instructorId) =>

--- a/ELearning.IntegrationTests/ELearning.IntegrationTests.csproj
+++ b/ELearning.IntegrationTests/ELearning.IntegrationTests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ELearning.IntegrationTests/OcelotGatewayModeTests.cs
+++ b/ELearning.IntegrationTests/OcelotGatewayModeTests.cs
@@ -1,4 +1,5 @@
 using ELearning.API.Infrastructure;
+using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 
 namespace ELearning.IntegrationTests;
@@ -14,7 +15,7 @@ public sealed class OcelotGatewayModeTests
 
         var enabled = OcelotGatewayMode.IsEnabled(configuration);
 
-        Assert.False(enabled);
+        enabled.Should().BeFalse();
     }
 
     [Theory]
@@ -31,6 +32,6 @@ public sealed class OcelotGatewayModeTests
 
         var enabled = OcelotGatewayMode.IsEnabled(configuration);
 
-        Assert.Equal(expected, enabled);
+        enabled.Should().Be(expected);
     }
 }


### PR DESCRIPTION
This PR updates test assertion style to use `FluentAssertions` consistently while keeping `FluentValidation` dedicated to validator-focused test scenarios.

**What changed**
- Replaced remaining `xUnit Assert.*` assertions with `FluentAssertions` (`.Should()`) in:
  - `ELearning.Application.Tests`
  - `ELearning.IntegrationTests`
- Restored `FluentAssertions` package references in test projects.
- Kept `FluentValidation` usage intact for DTO/input validation helper/tests only.

**Why**
- Improves readability and consistency of test assertions.
- Preserves clear separation of responsibilities:
  - `FluentAssertions` for assertion style
  - `FluentValidation` for validation logic testing

**Validation**
- `dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false`
- All tests passing:
  - `ELearning.Application.Tests`: 80
  - `ELearning.IntegrationTests`: 16