### PR TITLE
Updates docs and API correctness for portfolio-readiness.

### DIFF
--- a/ELearning.API/Middleware/GlobalExceptionMiddleware.cs
+++ b/ELearning.API/Middleware/GlobalExceptionMiddleware.cs
@@ -1,4 +1,5 @@
 using ELearning.Application.Common.Exceptions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ELearning.API.Middleware;
@@ -26,6 +27,7 @@ public sealed class GlobalExceptionMiddleware(RequestDelegate next, ILogger<Glob
             ForbiddenAccessException => (StatusCodes.Status403Forbidden, "Forbidden"),
             UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
             DomainApplicationException => (StatusCodes.Status400BadRequest, "Application error"),
+            DbUpdateConcurrencyException => (StatusCodes.Status409Conflict, "Concurrency conflict"),
             _ => (StatusCodes.Status500InternalServerError, "Internal server error")
         };
 
@@ -55,6 +57,6 @@ public sealed class GlobalExceptionMiddleware(RequestDelegate next, ILogger<Glob
 
         context.Response.StatusCode = statusCode;
         context.Response.ContentType = "application/problem+json";
-        await context.Response.WriteAsJsonAsync(problemDetails);
+        await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
     }
 }

--- a/ELearning.API/Program.cs
+++ b/ELearning.API/Program.cs
@@ -158,10 +158,6 @@ builder.Services.AddControllers()
     {
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
         options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-    })
-    .ConfigureApiBehaviorOptions(options =>
-    {
-        options.SuppressModelStateInvalidFilter = true;
     });
 
 // Add HttpContextAccessor for CurrentUserService

--- a/ELearning.IntegrationTests/AuthControllerIntegrationTests.cs
+++ b/ELearning.IntegrationTests/AuthControllerIntegrationTests.cs
@@ -39,4 +39,14 @@ public sealed class AuthControllerIntegrationTests : IClassFixture<TestWebApplic
         authResult.GetProperty("token").GetString().Should().Be("stub-token");
         authResult.GetProperty("email").GetString().Should().Be("sample.user@elearning.test");
     }
+
+    [Fact]
+    public async Task Login_WhenPayloadIsInvalid_ReturnsBadRequest()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var response = await _client.PostAsJsonAsync("/api/auth/login", new { }, cancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 }

--- a/ELearning.IntegrationTests/GlobalExceptionMiddlewareTests.cs
+++ b/ELearning.IntegrationTests/GlobalExceptionMiddlewareTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using ELearning.API.Middleware;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace ELearning.IntegrationTests;
+
+public sealed class GlobalExceptionMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_WhenDbUpdateConcurrencyExceptionIsThrown_ReturnsConflictProblemDetails()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        var middleware = new GlobalExceptionMiddleware(
+            _ => throw new DbUpdateConcurrencyException("Concurrency update conflict."),
+            NullLogger<GlobalExceptionMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        context.Response.ContentType.Should().StartWith("application/problem+json");
+
+        context.Response.Body.Position = 0;
+        using var payload = await JsonDocument.ParseAsync(context.Response.Body, cancellationToken: cancellationToken);
+        payload.RootElement.GetProperty("status").GetInt32().Should().Be(StatusCodes.Status409Conflict);
+        payload.RootElement.GetProperty("title").GetString().Should().Be("Concurrency conflict");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is curated as portfolio code for senior/backend engineering inte
 - Aggregate-focused domain model with value objects and invariants
 - Application Facade (`IApiFacade`/`ApiFacade`) as a single API entrypoint for use-case dispatch
 - Provider-aware database startup strategy (SQL Server migrations, sqlite in-memory bootstrap)
-- Domain event dispatch via MediatR from `ApplicationDbContext`
+- Outbox pattern for reliable domain-event delivery with background dispatch
 - Optional Ocelot gateway mode with explicit configuration switch
 - Consistent API envelope responses for REST and a secondary GraphQL surface
 - Integration point pattern for external read models (Dapr-style fallback)
@@ -96,7 +96,7 @@ dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
 Current test status from latest local run:
 
 - `ELearning.Application.Tests`: 80 passed
-- `ELearning.IntegrationTests`: 16 passed
+- `ELearning.IntegrationTests`: 18 passed
 
 ## API Notes
 
@@ -110,7 +110,7 @@ Current test status from latest local run:
 - Business logic is centered in Application + Domain, not controllers.
 - Request validation and transaction handling are centralized via MediatR behaviors.
 - Controller orchestration is simplified via an Application Facade.
-- Domain events are dispatched in-process through MediatR.
+- Domain events are persisted to an outbox and dispatched by a background worker.
 - The codebase shows clear seams for scaling later (read services, facades, abstractions).
 - Test projects are separated by responsibility (application-level vs integration-level).
 - Integration tests now cover real auth/JWT and protected endpoint authorization behavior.
@@ -118,11 +118,10 @@ Current test status from latest local run:
 ## Roadmap (High-Impact Next Additions)
 
 - Add architecture tests enforcing layer dependency rules in CI.
-- Add optimistic concurrency (row version tokens) for write-heavy aggregates.
 - Add end-to-end integration scenarios for enrollment/submission command workflows.
 - Add migration assets and deployment guidance for SQL Server environments.
-- Evolve domain event handling to outbox/background delivery for reliability.
-- Expand auth story with refresh tokens/revocation and audit events.
+- Add API-level optimistic concurrency conflict handling (`DbUpdateConcurrencyException` -> HTTP `409`).
+- Tighten auth request validation and token revocation ownership checks.
 
 ## License
 


### PR DESCRIPTION
Syncs README with actual implementation and current test status.
Fixes API conflict semantics by returning 409 Conflict for EF optimistic concurrency exceptions.
Restores automatic request validation for auth endpoints via [ApiController] model-state behavior.
Adds integration tests covering invalid auth payloads (400) and concurrency conflict mapping (409).
Included commits
docs(readme): align portfolio documentation with implemented architecture and latest test status
fix(api): return 409 for EF concurrency conflicts and re-enable automatic auth model validation with integration coverage
Why this matters
Improves credibility of the repository as a production-style monolith sample.
Ensures documented architecture matches shipped behavior.
Makes API error handling and validation behavior consistent with modern .NET best practices.