### PR TITLE
Introduce consistent API error contracts

### DIFF
--- a/ELearning.API/Controllers/ApiControllerBase.cs
+++ b/ELearning.API/Controllers/ApiControllerBase.cs
@@ -5,6 +5,8 @@
 namespace ELearning.API.Controllers;
 
 using ELearning.API.Contracts;
+using ELearning.API.Infrastructure;
+using ELearning.Application.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 using ApplicationModel = ELearning.Application.Common.Model;
 using Result = ELearning.Application.Common.Model.Result;
@@ -12,45 +14,49 @@ using Result = ELearning.Application.Common.Model.Result;
 [ApiController]
 public abstract class ApiControllerBase : ControllerBase
 {
-    protected ActionResult<ApiResponse<T>> FromResult<T>(ApplicationModel.Result<T> result, Func<string, bool>? isNotFound = null)
+    protected ActionResult<ApiResponse<T>> FromResult<T>(ApplicationModel.Result<T> result)
     {
         if (result.IsSuccess)
         {
             return this.Ok(ApiResponse<T>.Success(result.Value));
         }
 
-        return this.BuildFailure<T>(result.Error, isNotFound);
+        return this.FromError<T>(result.ErrorDetails);
     }
 
-    protected ActionResult<ApiResponse<object?>> FromResult(Result result, Func<string, bool>? isNotFound = null)
+    protected ActionResult<ApiResponse<object?>> FromResult(Result result)
     {
         if (result.IsSuccess)
         {
             return this.Ok(ApiResponse<object?>.Success(null));
         }
 
-        return this.BuildFailure<object?>(result.Error, isNotFound);
+        return this.FromError<object?>(result.ErrorDetails);
     }
 
     protected ActionResult<ApiResponse<object?>> CreatedResponse() =>
         this.StatusCode(StatusCodes.Status201Created, ApiResponse<object?>.Success(null));
 
     protected ActionResult<ApiResponse<T>> UnauthorizedResponse<T>(string message) =>
-        this.Unauthorized(ApiResponse<T>.Failure("unauthorized", message));
+        this.FromError<T>(ApplicationError.Unauthorized(message));
 
     protected ActionResult<ApiResponse<T>> BadRequestResponse<T>(string message) =>
-        this.BadRequest(ApiResponse<T>.Failure("bad_request", message));
+        this.FromError<T>(ApplicationError.BadRequest(message));
 
     protected ActionResult<ApiResponse<T>> NotFoundResponse<T>(string message) =>
-        this.NotFound(ApiResponse<T>.Failure("not_found", message));
+        this.FromError<T>(ApplicationError.NotFound(message));
 
-    private ActionResult<ApiResponse<T>> BuildFailure<T>(string message, Func<string, bool>? isNotFound)
+    protected ActionResult<ApiResponse<T>> RouteIdMismatchResponse<T>(string payloadIdName) =>
+        this.FromError<T>(ApplicationError.BadRequest(
+            $"Route id does not match payload {payloadIdName}.",
+            ApplicationErrorCodes.RouteIdMismatch));
+
+    protected ActionResult<ApiResponse<T>> FromError<T>(ApplicationError? error)
     {
-        if (isNotFound?.Invoke(message) == true)
-        {
-            return this.NotFoundResponse<T>(message);
-        }
+        var problemDetails = ApiProblemDetailsFactory.Create(
+            this.HttpContext,
+            error ?? ApplicationError.BadRequest("The request could not be completed."));
 
-        return this.BadRequestResponse<T>(message);
+        return ApiProblemDetailsFactory.ToObjectResult(problemDetails);
     }
 }

--- a/ELearning.API/Controllers/AuthController.cs
+++ b/ELearning.API/Controllers/AuthController.cs
@@ -101,6 +101,6 @@ public class AuthController(IApiFacade apiFacade) : ApiControllerBase
             new RevokeRefreshTokenCommand(request.RefreshToken),
             cancellationToken);
 
-        return result.IsSuccess ? this.Ok(ApiResponse<object?>.Success(null)) : this.BadRequestResponse<object?>(result.Error);
+        return result.IsSuccess ? this.Ok(ApiResponse<object?>.Success(null)) : this.FromError<object?>(result.ErrorDetails);
     }
 }

--- a/ELearning.API/Controllers/CertificatesController.cs
+++ b/ELearning.API/Controllers/CertificatesController.cs
@@ -31,7 +31,7 @@ public sealed class CertificatesController(IApiFacade apiFacade) : ApiController
             new IssueCertificateForCompletedEnrollmentCommand(enrollmentId),
             cancellationToken);
 
-        return this.FromResult(result, error => error.StartsWith("Enrollment not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("enrollments/{enrollmentId:guid}")]
@@ -43,7 +43,7 @@ public sealed class CertificatesController(IApiFacade apiFacade) : ApiController
         CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new GetEnrollmentCertificateQuery(enrollmentId), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Certificate not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("verify/{certificateCode}")]
@@ -54,6 +54,6 @@ public sealed class CertificatesController(IApiFacade apiFacade) : ApiController
         CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new VerifyCertificateQuery(certificateCode), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Certificate not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 }

--- a/ELearning.API/Controllers/CoursesController.cs
+++ b/ELearning.API/Controllers/CoursesController.cs
@@ -52,7 +52,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     {
         var query = new GetCourseDetailQuery { CourseId = id };
         var result = await apiFacade.SendAsync(query, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("{id:guid}/reviews")]
@@ -61,7 +61,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     public async Task<ActionResult<ApiResponse<IReadOnlyList<ReviewDto>>>> GetCourseReviews(Guid id, CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new GetCourseReviewsQuery(id), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("featured")]
@@ -79,7 +79,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(query, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<List<CourseListDto>>(result.Error);
+            return this.FromError<List<CourseListDto>>(result.ErrorDetails);
         }
 
         return this.Ok(ApiResponse<List<CourseListDto>>.Success(result.Value.Items.ToList()));
@@ -99,7 +99,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(query, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<List<CourseListDto>>(result.Error);
+            return this.FromError<List<CourseListDto>>(result.ErrorDetails);
         }
 
         return this.Ok(ApiResponse<List<CourseListDto>>.Success(result.Value.Items.ToList()));
@@ -116,7 +116,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<object?>(result.Error);
+            return this.FromError<object?>(result.ErrorDetails);
         }
 
         return this.CreatedResponse();
@@ -134,11 +134,11 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     {
         if (id != command.CourseId)
         {
-            return this.BadRequestResponse<object?>("Route id does not match payload CourseId.");
+            return this.RouteIdMismatchResponse<object?>("CourseId");
         }
 
         var result = await apiFacade.SendAsync(command, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost("{courseId:guid}/modules")]
@@ -160,7 +160,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<Guid>(result.Error);
+            return this.FromError<Guid>(result.ErrorDetails);
         }
 
         return this.StatusCode(StatusCodes.Status201Created, ApiResponse<Guid>.Success(result.Value));
@@ -191,7 +191,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<Guid>(result.Error);
+            return this.FromError<Guid>(result.ErrorDetails);
         }
 
         return this.StatusCode(StatusCodes.Status201Created, ApiResponse<Guid>.Success(result.Value));
@@ -220,7 +220,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<Guid>(result.Error);
+            return this.FromError<Guid>(result.ErrorDetails);
         }
 
         return this.StatusCode(StatusCodes.Status201Created, ApiResponse<Guid>.Success(result.Value));
@@ -233,7 +233,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     public async Task<ActionResult<ApiResponse<object?>>> DeleteCourse(Guid id, CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new DeleteCourseCommand(id), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost("{id:guid}/submit-for-review")]
@@ -244,7 +244,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     public async Task<ActionResult<ApiResponse<object?>>> SubmitForReview(Guid id, CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new SubmitCourseForReviewCommand(id), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost("{id:guid}/approve-publication")]
@@ -255,7 +255,7 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     public async Task<ActionResult<ApiResponse<object?>>> ApprovePublication(Guid id, CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new ApproveCoursePublicationCommand(id), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost("{id:guid}/reject-publication")]
@@ -270,11 +270,11 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     {
         if (id != command.CourseId)
         {
-            return this.BadRequestResponse<object?>("Route id does not match payload CourseId.");
+            return this.RouteIdMismatchResponse<object?>("CourseId");
         }
 
         var result = await apiFacade.SendAsync(command, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost("{id:guid}/archive")]
@@ -285,6 +285,6 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     public async Task<ActionResult<ApiResponse<object?>>> Archive(Guid id, CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new ArchiveCourseCommand(id), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Course not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 }

--- a/ELearning.API/Controllers/EnrollmentsController.cs
+++ b/ELearning.API/Controllers/EnrollmentsController.cs
@@ -27,7 +27,7 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
     {
         var query = new GetEnrollmentDetailQuery { EnrollmentId = id };
         var result = await apiFacade.SendAsync(query, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Enrollment not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost]
@@ -41,7 +41,7 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<object?>(result.Error);
+            return this.FromError<object?>(result.ErrorDetails);
         }
 
         return this.CreatedResponse();
@@ -58,7 +58,7 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
         CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new StartLessonCommand(id, lessonId), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Enrollment not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost("{id:guid}/lessons/{lessonId:guid}/complete")]
@@ -72,7 +72,7 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
         CancellationToken cancellationToken)
     {
         var result = await apiFacade.SendAsync(new CompleteLessonCommand(id, lessonId), cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Enrollment not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPut("{id:guid}/status")]
@@ -87,11 +87,11 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
     {
         if (id != command.EnrollmentId)
         {
-            return this.BadRequestResponse<object?>("Route id does not match payload EnrollmentId.");
+            return this.RouteIdMismatchResponse<object?>("EnrollmentId");
         }
 
         var result = await apiFacade.SendAsync(command, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Enrollment not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost("{id:guid}/review")]
@@ -108,6 +108,6 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
             new ReviewCourseCommand(id, request.Rating, request.Review),
             cancellationToken);
 
-        return this.FromResult(result, error => error.StartsWith("Enrollment not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 }

--- a/ELearning.API/Controllers/InstructorsController.cs
+++ b/ELearning.API/Controllers/InstructorsController.cs
@@ -28,7 +28,7 @@ public class InstructorsController(IApiFacade apiFacade) : ApiControllerBase
     {
         var query = new GetInstructorProfileQuery { InstructorId = id };
         var result = await apiFacade.SendAsync(query, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Instructor not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("{id:guid}/with-courses")]
@@ -38,7 +38,7 @@ public class InstructorsController(IApiFacade apiFacade) : ApiControllerBase
     {
         var query = new GetInstructorCoursesQuery { InstructorId = id };
         var result = await apiFacade.SendAsync(query, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Instructor not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("{id:guid}/pending-submissions")]

--- a/ELearning.API/Controllers/StudentsController.cs
+++ b/ELearning.API/Controllers/StudentsController.cs
@@ -26,7 +26,7 @@ public class StudentsController(IApiFacade apiFacade) : ApiControllerBase
     {
         var query = new GetStudentProfileQuery { StudentId = id };
         var result = await apiFacade.SendAsync(query, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Student not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("{id:guid}/progress")]
@@ -37,7 +37,7 @@ public class StudentsController(IApiFacade apiFacade) : ApiControllerBase
     {
         var query = new GetStudentProgressQuery { StudentId = id };
         var result = await apiFacade.SendAsync(query, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Student", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpGet("{id:guid}/enrollments")]

--- a/ELearning.API/Controllers/SubmissionsController.cs
+++ b/ELearning.API/Controllers/SubmissionsController.cs
@@ -26,7 +26,7 @@ public class SubmissionsController(IApiFacade apiFacade) : ApiControllerBase
     {
         var query = new GetSubmissionDetailQuery { SubmissionId = id };
         var result = await apiFacade.SendAsync(query, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Submission not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 
     [HttpPost]
@@ -40,7 +40,7 @@ public class SubmissionsController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.BadRequestResponse<object?>(result.Error);
+            return this.FromError<object?>(result.ErrorDetails);
         }
 
         return this.CreatedResponse();
@@ -58,10 +58,10 @@ public class SubmissionsController(IApiFacade apiFacade) : ApiControllerBase
     {
         if (id != command.SubmissionId)
         {
-            return this.BadRequestResponse<object?>("Route id does not match payload SubmissionId.");
+            return this.RouteIdMismatchResponse<object?>("SubmissionId");
         }
 
         var result = await apiFacade.SendAsync(command, cancellationToken);
-        return this.FromResult(result, error => error.StartsWith("Submission not found", StringComparison.OrdinalIgnoreCase));
+        return this.FromResult(result);
     }
 }

--- a/ELearning.API/Infrastructure/ApiProblemDetailsFactory.cs
+++ b/ELearning.API/Infrastructure/ApiProblemDetailsFactory.cs
@@ -1,0 +1,110 @@
+// <copyright file="ApiProblemDetailsFactory.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Infrastructure;
+
+using ELearning.Application.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+public static class ApiProblemDetailsFactory
+{
+    public const string ContentType = "application/problem+json";
+
+    public static ProblemDetails Create(HttpContext httpContext, ApplicationError error)
+    {
+        var statusCode = GetStatusCode(error.Type);
+        return Create(httpContext, statusCode, GetTitle(error.Type), error.Message, error.Code);
+    }
+
+    public static ProblemDetails Create(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string code)
+    {
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = httpContext.Request.Path,
+        };
+
+        AddExtensions(problemDetails, httpContext, code);
+        return problemDetails;
+    }
+
+    public static ValidationProblemDetails CreateValidation(
+        HttpContext httpContext,
+        IDictionary<string, string[]> errors,
+        string detail = "One or more validation failures have occurred.")
+    {
+        var problemDetails = new ValidationProblemDetails(errors)
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Validation failed",
+            Detail = detail,
+            Instance = httpContext.Request.Path,
+        };
+
+        AddExtensions(problemDetails, httpContext, ApplicationErrorCodes.ValidationFailed);
+        return problemDetails;
+    }
+
+    public static ObjectResult ToObjectResult(ProblemDetails problemDetails)
+    {
+        var result = new ObjectResult(problemDetails)
+        {
+            StatusCode = problemDetails.Status,
+        };
+
+        result.ContentTypes.Add(ContentType);
+        return result;
+    }
+
+    public static async Task WriteAsync(HttpContext httpContext, ProblemDetails problemDetails)
+    {
+        httpContext.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status500InternalServerError;
+        httpContext.Response.ContentType = ContentType;
+
+        if (problemDetails is ValidationProblemDetails validationProblemDetails)
+        {
+            await httpContext.Response.WriteAsJsonAsync(validationProblemDetails, options: null, contentType: ContentType);
+            return;
+        }
+
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: ContentType);
+    }
+
+    private static int GetStatusCode(ErrorType errorType) =>
+        errorType switch
+        {
+            ErrorType.Validation => StatusCodes.Status400BadRequest,
+            ErrorType.BadRequest => StatusCodes.Status400BadRequest,
+            ErrorType.NotFound => StatusCodes.Status404NotFound,
+            ErrorType.Conflict => StatusCodes.Status409Conflict,
+            ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
+            ErrorType.Forbidden => StatusCodes.Status403Forbidden,
+            _ => StatusCodes.Status400BadRequest,
+        };
+
+    private static string GetTitle(ErrorType errorType) =>
+        errorType switch
+        {
+            ErrorType.Validation => "Validation failed",
+            ErrorType.BadRequest => "Invalid request",
+            ErrorType.NotFound => "Resource not found",
+            ErrorType.Conflict => "Conflict",
+            ErrorType.Unauthorized => "Unauthorized",
+            ErrorType.Forbidden => "Forbidden",
+            _ => "Invalid request",
+        };
+
+    private static void AddExtensions(ProblemDetails problemDetails, HttpContext httpContext, string code)
+    {
+        problemDetails.Extensions["code"] = code;
+        problemDetails.Extensions["traceId"] = httpContext.TraceIdentifier;
+    }
+}

--- a/ELearning.API/Middleware/GlobalExceptionMiddleware.cs
+++ b/ELearning.API/Middleware/GlobalExceptionMiddleware.cs
@@ -4,7 +4,9 @@
 
 namespace ELearning.API.Middleware;
 
+using ELearning.API.Infrastructure;
 using ELearning.Application.Common.Exceptions;
+using ELearning.Application.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -24,15 +26,43 @@ public sealed class GlobalExceptionMiddleware(RequestDelegate next, ILogger<Glob
 
     private async Task HandleExceptionAsync(HttpContext context, Exception exception)
     {
-        var (statusCode, title) = exception switch
+        var (statusCode, title, code, detail) = exception switch
         {
-            ValidationException => (StatusCodes.Status400BadRequest, "Validation failed"),
-            NotFoundException => (StatusCodes.Status404NotFound, "Resource not found"),
-            ForbiddenAccessException => (StatusCodes.Status403Forbidden, "Forbidden"),
-            UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
-            DomainApplicationException => (StatusCodes.Status400BadRequest, "Application error"),
-            DbUpdateConcurrencyException => (StatusCodes.Status409Conflict, "Concurrency conflict"),
-            _ => (StatusCodes.Status500InternalServerError, "Internal server error"),
+            ValidationException => (
+                StatusCodes.Status400BadRequest,
+                "Validation failed",
+                ApplicationErrorCodes.ValidationFailed,
+                exception.Message),
+            NotFoundException => (
+                StatusCodes.Status404NotFound,
+                "Resource not found",
+                ApplicationErrorCodes.ResourceNotFound,
+                exception.Message),
+            ForbiddenAccessException => (
+                StatusCodes.Status403Forbidden,
+                "Forbidden",
+                ApplicationErrorCodes.AuthorizationForbidden,
+                exception.Message),
+            UnauthorizedAccessException => (
+                StatusCodes.Status401Unauthorized,
+                "Unauthorized",
+                ApplicationErrorCodes.AuthenticationUnauthorized,
+                exception.Message),
+            DomainApplicationException => (
+                StatusCodes.Status400BadRequest,
+                "Invalid request",
+                ApplicationErrorCodes.RequestInvalid,
+                exception.Message),
+            DbUpdateConcurrencyException => (
+                StatusCodes.Status409Conflict,
+                "Concurrency conflict",
+                ApplicationErrorCodes.ConcurrencyConflict,
+                exception.Message),
+            _ => (
+                StatusCodes.Status500InternalServerError,
+                "Internal server error",
+                ApplicationErrorCodes.UnexpectedError,
+                "An unexpected error occurred."),
         };
 
         if (statusCode >= 500)
@@ -44,23 +74,10 @@ public sealed class GlobalExceptionMiddleware(RequestDelegate next, ILogger<Glob
             logger.LogWarning(exception, "Handled exception for request {Method} {Path}", context.Request.Method, context.Request.Path);
         }
 
-        var problemDetails = new ProblemDetails
-        {
-            Status = statusCode,
-            Title = title,
-            Detail = exception.Message,
-            Instance = context.Request.Path,
-        };
+        ProblemDetails problemDetails = exception is ValidationException validationException
+            ? ApiProblemDetailsFactory.CreateValidation(context, validationException.Errors, detail)
+            : ApiProblemDetailsFactory.Create(context, statusCode, title, detail, code);
 
-        problemDetails.Extensions["traceId"] = context.TraceIdentifier;
-
-        if (exception is ValidationException validationException)
-        {
-            problemDetails.Extensions["errors"] = validationException.Errors;
-        }
-
-        context.Response.StatusCode = statusCode;
-        context.Response.ContentType = "application/problem+json";
-        await context.Response.WriteAsJsonAsync(problemDetails, options: null, contentType: "application/problem+json");
+        await ApiProblemDetailsFactory.WriteAsync(context, problemDetails);
     }
 }

--- a/ELearning.API/Program.cs
+++ b/ELearning.API/Program.cs
@@ -14,6 +14,7 @@ using ELearning.Application;
 using ELearning.Infrastructure;
 using ELearning.Infrastructure.DaprServices;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
@@ -109,6 +110,44 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             IssuerSigningKey = new SymmetricSecurityKey(
                 Encoding.UTF8.GetBytes(jwtSettings["Secret"] ?? throw new InvalidOperationException("JWT Secret is not configured"))),
         };
+
+        options.Events = new JwtBearerEvents
+        {
+            OnChallenge = async context =>
+            {
+                context.HandleResponse();
+
+                if (context.Response.HasStarted)
+                {
+                    return;
+                }
+
+                var problemDetails = ApiProblemDetailsFactory.Create(
+                    context.HttpContext,
+                    StatusCodes.Status401Unauthorized,
+                    "Unauthorized",
+                    "Authentication is required to access this resource.",
+                    ELearning.Application.Common.Model.ApplicationErrorCodes.AuthenticationUnauthorized);
+
+                await ApiProblemDetailsFactory.WriteAsync(context.HttpContext, problemDetails);
+            },
+            OnForbidden = async context =>
+            {
+                if (context.Response.HasStarted)
+                {
+                    return;
+                }
+
+                var problemDetails = ApiProblemDetailsFactory.Create(
+                    context.HttpContext,
+                    StatusCodes.Status403Forbidden,
+                    "Forbidden",
+                    "You do not have permission to access this resource.",
+                    ELearning.Application.Common.Model.ApplicationErrorCodes.AuthorizationForbidden);
+
+                await ApiProblemDetailsFactory.WriteAsync(context.HttpContext, problemDetails);
+            },
+        };
     });
 
 builder.Services.AddRateLimiter(options =>
@@ -171,6 +210,25 @@ builder.Services.AddControllers()
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
         options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
     });
+
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.InvalidModelStateResponseFactory = context =>
+    {
+        var errors = context.ModelState
+            .Where(entry => entry.Value?.Errors.Count > 0)
+            .ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value!.Errors
+                    .Select(error => string.IsNullOrWhiteSpace(error.ErrorMessage)
+                        ? "The input was not valid."
+                        : error.ErrorMessage)
+                    .ToArray());
+
+        var problemDetails = ApiProblemDetailsFactory.CreateValidation(context.HttpContext, errors);
+        return ApiProblemDetailsFactory.ToObjectResult(problemDetails);
+    };
+});
 
 // Add HttpContextAccessor for CurrentUserService
 builder.Services.AddHttpContextAccessor();

--- a/ELearning.Application/Auth/Handlers/RevokeRefreshTokenCommandHandler.cs
+++ b/ELearning.Application/Auth/Handlers/RevokeRefreshTokenCommandHandler.cs
@@ -28,7 +28,7 @@ public sealed class RevokeRefreshTokenCommandHandler(
         if (refreshTokenState is null)
         {
             await securityAuditWriter.WriteAsync(null, "auth.revoke", false, "Refresh token not found", cancellationToken);
-            return Result.Failure("Refresh token was not found.");
+            return Result.Failure(ApplicationError.BadRequest("Refresh token was not found."));
         }
 
         var currentUserId = currentUserService.UserId.Value;

--- a/ELearning.Application/Certificates/Handlers/GetEnrollmentCertificateQueryHandler.cs
+++ b/ELearning.Application/Certificates/Handlers/GetEnrollmentCertificateQueryHandler.cs
@@ -28,7 +28,7 @@ public sealed class GetEnrollmentCertificateQueryHandler(
         var certificate = await certificateReadRepository.GetByEnrollmentIdAsync(request.EnrollmentId, cancellationToken);
         if (certificate is null)
         {
-            return Result.Failure<CertificateDto>("Certificate not found for enrollment.");
+            return Result.Failure<CertificateDto>(ApplicationError.NotFound("Certificate not found for enrollment."));
         }
 
         var isOwner = certificate.StudentId == currentUserService.UserId.Value;

--- a/ELearning.Application/Certificates/Handlers/IssueCertificateForCompletedEnrollmentCommandHandler.cs
+++ b/ELearning.Application/Certificates/Handlers/IssueCertificateForCompletedEnrollmentCommandHandler.cs
@@ -62,12 +62,12 @@ public sealed class IssueCertificateForCompletedEnrollmentCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure<CertificateDto>(ex.Message);
+            return Result.Failure<CertificateDto>(ApplicationError.Conflict(ex.Message));
         }
 
         if (certificate is null)
         {
-            return Result.Failure<CertificateDto>("Certificates are available only after successful course completion.");
+            return Result.Failure<CertificateDto>(ApplicationError.Conflict("Certificates are available only after successful course completion."));
         }
 
         return Result.Success(new CertificateDto(

--- a/ELearning.Application/Certificates/Handlers/VerifyCertificateQueryHandler.cs
+++ b/ELearning.Application/Certificates/Handlers/VerifyCertificateQueryHandler.cs
@@ -18,7 +18,7 @@ public sealed class VerifyCertificateQueryHandler(ICertificateReadRepository cer
         var certificate = await certificateReadRepository.GetByCodeAsync(request.CertificateCode, cancellationToken);
         if (certificate is null)
         {
-            return Result.Failure<CertificateDto>("Certificate not found.");
+            return Result.Failure<CertificateDto>(ApplicationError.NotFound("Certificate not found."));
         }
 
         return Result.Success(new CertificateDto(

--- a/ELearning.Application/Common/Model/ApplicationError.cs
+++ b/ELearning.Application/Common/Model/ApplicationError.cs
@@ -1,0 +1,61 @@
+// <copyright file="ApplicationError.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Application.Common.Model;
+
+public sealed record ApplicationError(string Code, string Message, ErrorType Type)
+{
+    public static ApplicationError BadRequest(
+        string message,
+        string code = ApplicationErrorCodes.RequestInvalid) =>
+        new(code, message, ErrorType.BadRequest);
+
+    public static ApplicationError Validation(
+        string message,
+        string code = ApplicationErrorCodes.ValidationFailed) =>
+        new(code, message, ErrorType.Validation);
+
+    public static ApplicationError NotFound(
+        string message,
+        string code = ApplicationErrorCodes.ResourceNotFound) =>
+        new(code, message, ErrorType.NotFound);
+
+    public static ApplicationError Conflict(
+        string message,
+        string code = ApplicationErrorCodes.BusinessRuleConflict) =>
+        new(code, message, ErrorType.Conflict);
+
+    public static ApplicationError Unauthorized(
+        string message,
+        string code = ApplicationErrorCodes.AuthenticationUnauthorized) =>
+        new(code, message, ErrorType.Unauthorized);
+
+    public static ApplicationError Forbidden(
+        string message,
+        string code = ApplicationErrorCodes.AuthorizationForbidden) =>
+        new(code, message, ErrorType.Forbidden);
+}
+
+public enum ErrorType
+{
+    BadRequest = 1,
+    Validation = 2,
+    NotFound = 3,
+    Conflict = 4,
+    Unauthorized = 5,
+    Forbidden = 6,
+}
+
+public static class ApplicationErrorCodes
+{
+    public const string ValidationFailed = "validation.failed";
+    public const string RequestInvalid = "request.invalid";
+    public const string RouteIdMismatch = "request.route_id_mismatch";
+    public const string ResourceNotFound = "resource.not_found";
+    public const string BusinessRuleConflict = "conflict.business_rule";
+    public const string ConcurrencyConflict = "conflict.concurrency";
+    public const string AuthenticationUnauthorized = "authentication.unauthorized";
+    public const string AuthorizationForbidden = "authorization.forbidden";
+    public const string UnexpectedError = "error.unexpected";
+}

--- a/ELearning.Application/Common/Model/Result.cs
+++ b/ELearning.Application/Common/Model/Result.cs
@@ -14,16 +14,18 @@ public sealed class Result<T>
 
     public string Error { get; }
 
+    public ApplicationError? ErrorDetails { get; }
+
     public T Value =>
         this.IsSuccess
             ? this.value!
             : throw new InvalidOperationException("Cannot access Value on a failed result.");
 
-    private Result(bool isSuccess, T? value, string error)
+    private Result(bool isSuccess, T? value, ApplicationError? error)
     {
         if (isSuccess)
         {
-            if (!string.IsNullOrEmpty(error))
+            if (error is not null)
             {
                 throw new ArgumentException("Successful result cannot contain an error.", nameof(error));
             }
@@ -35,21 +37,25 @@ public sealed class Result<T>
         }
         else
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(error);
+            ArgumentNullException.ThrowIfNull(error);
+            ArgumentException.ThrowIfNullOrWhiteSpace(error.Message);
         }
 
         this.IsSuccess = isSuccess;
         this.value = value;
-        this.Error = error;
+        this.ErrorDetails = error;
+        this.Error = error?.Message ?? string.Empty;
     }
 
     public static Result<T> Success(T value)
     {
         ArgumentNullException.ThrowIfNull(value);
-        return new Result<T>(true, value, string.Empty);
+        return new Result<T>(true, value, null);
     }
 
-    public static Result<T> Failure(string error) => new Result<T>(false, default, error);
+    public static Result<T> Failure(string error) => Failure(ApplicationError.BadRequest(error));
+
+    public static Result<T> Failure(ApplicationError error) => new Result<T>(false, default, error);
 
     public TResult Match<TResult>(Func<T, TResult> onSuccess, Func<string, TResult> onFailure)
     {
@@ -67,31 +73,39 @@ public sealed class Result
 
     public string Error { get; }
 
-    private Result(bool isSuccess, string error)
+    public ApplicationError? ErrorDetails { get; }
+
+    private Result(bool isSuccess, ApplicationError? error)
     {
         if (isSuccess)
         {
-            if (!string.IsNullOrEmpty(error))
+            if (error is not null)
             {
                 throw new ArgumentException("Successful result cannot contain an error.", nameof(error));
             }
         }
         else
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(error);
+            ArgumentNullException.ThrowIfNull(error);
+            ArgumentException.ThrowIfNullOrWhiteSpace(error.Message);
         }
 
         this.IsSuccess = isSuccess;
-        this.Error = error;
+        this.ErrorDetails = error;
+        this.Error = error?.Message ?? string.Empty;
     }
 
-    public static Result Success() => new Result(true, string.Empty);
+    public static Result Success() => new Result(true, null);
 
-    public static Result Failure(string error) => new Result(false, error);
+    public static Result Failure(string error) => Failure(ApplicationError.BadRequest(error));
+
+    public static Result Failure(ApplicationError error) => new Result(false, error);
 
     public static Result<T> Success<T>(T value) => Result<T>.Success(value);
 
     public static Result<T> Failure<T>(string error) => Result<T>.Failure(error);
+
+    public static Result<T> Failure<T>(ApplicationError error) => Result<T>.Failure(error);
 
     public TResult Match<TResult>(Func<TResult> onSuccess, Func<string, TResult> onFailure)
     {

--- a/ELearning.Application/Courses/Handlers/AddCourseAssignmentCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/AddCourseAssignmentCommandHandler.cs
@@ -39,7 +39,7 @@ public sealed class AddCourseAssignmentCommandHandler(
 
         if (assignmentType is null)
         {
-            return Result.Failure<Guid>($"Invalid assignment type: {request.TypeId}");
+            return Result.Failure<Guid>(ApplicationError.BadRequest($"Invalid assignment type: {request.TypeId}"));
         }
 
         Assignment assignment;
@@ -61,7 +61,7 @@ public sealed class AddCourseAssignmentCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or ArgumentOutOfRangeException)
         {
-            return Result.Failure<Guid>(ex.Message);
+            return Result.Failure<Guid>(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/AddCourseLessonCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/AddCourseLessonCommandHandler.cs
@@ -40,7 +40,7 @@ public sealed class AddCourseLessonCommandHandler(
 
         if (lessonType is null)
         {
-            return Result.Failure<Guid>($"Invalid lesson type: {request.TypeId}");
+            return Result.Failure<Guid>(ApplicationError.BadRequest($"Invalid lesson type: {request.TypeId}"));
         }
 
         Lesson lesson;
@@ -64,7 +64,7 @@ public sealed class AddCourseLessonCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or ArgumentOutOfRangeException)
         {
-            return Result.Failure<Guid>(ex.Message);
+            return Result.Failure<Guid>(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/AddCourseModuleCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/AddCourseModuleCommandHandler.cs
@@ -40,7 +40,7 @@ public sealed class AddCourseModuleCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
         {
-            return Result.Failure<Guid>(ex.Message);
+            return Result.Failure<Guid>(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/ApproveCoursePublicationCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/ApproveCoursePublicationCommandHandler.cs
@@ -37,7 +37,7 @@ public sealed class ApproveCoursePublicationCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/ArchiveCourseCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/ArchiveCourseCommandHandler.cs
@@ -33,7 +33,7 @@ public sealed class ArchiveCourseCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/CreateCourseCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/CreateCourseCommandHandler.cs
@@ -41,7 +41,8 @@ public class CreateCourseCommandHandler(ICourseRepository courseRepository,
 
         if (category is null || level is null)
         {
-            return Result.Failure($"Invalid category or level. Category: {category?.Name ?? "null"}, Level: {level?.Name ?? "null"}");
+            return Result.Failure(ApplicationError.BadRequest(
+                $"Invalid category or level. Category: {category?.Name ?? "null"}, Level: {level?.Name ?? "null"}"));
         }
 
         // Create duration value object

--- a/ELearning.Application/Courses/Handlers/DeleteCourseCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/DeleteCourseCommandHandler.cs
@@ -43,7 +43,7 @@ public class DeleteCourseCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.DeleteAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/RejectCoursePublicationCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/RejectCoursePublicationCommandHandler.cs
@@ -37,7 +37,7 @@ public sealed class RejectCoursePublicationCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/SubmitCourseForReviewCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/SubmitCourseForReviewCommandHandler.cs
@@ -38,7 +38,7 @@ public sealed class SubmitCourseForReviewCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Courses/Handlers/UpdateCourseCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/UpdateCourseCommandHandler.cs
@@ -47,7 +47,8 @@ public class UpdateCourseCommandHandler(
 
         if (category is null || level is null)
         {
-            return Result.Failure($"Invalid category or level. Category: {category?.Name ?? "null"}, Level: {level?.Name ?? "null"}");
+            return Result.Failure(ApplicationError.BadRequest(
+                $"Invalid category or level. Category: {category?.Name ?? "null"}, Level: {level?.Name ?? "null"}"));
         }
 
         try
@@ -64,7 +65,7 @@ public class UpdateCourseCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await courseRepository.UpdateAsync(course, cancellationToken);

--- a/ELearning.Application/Enrollments/Handlers/CompleteLessonCommandHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/CompleteLessonCommandHandler.cs
@@ -42,7 +42,7 @@ public sealed class CompleteLessonCommandHandler(
 
         if (!course.ContainsLesson(request.LessonId))
         {
-            return Result.Failure("The lesson does not belong to the enrolled course.");
+            return Result.Failure(ApplicationError.Conflict("The lesson does not belong to the enrolled course."));
         }
 
         try
@@ -55,7 +55,7 @@ public sealed class CompleteLessonCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);

--- a/ELearning.Application/Enrollments/Handlers/CreateEnrollmentCommandHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/CreateEnrollmentCommandHandler.cs
@@ -47,14 +47,14 @@ public class CreateEnrollmentCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         // Check if student is already enrolled
         var alreadyEnrolled = await enrollmentRepository.GetByStudentAndCourseIdAsync(studentId, request.CourseId, cancellationToken) is not null;
         if (alreadyEnrolled)
         {
-            return Result.Failure("You are already enrolled in this course.");
+            return Result.Failure(ApplicationError.Conflict("You are already enrolled in this course."));
         }
 
         var enrollment = new Enrollment(studentId, course.Id);

--- a/ELearning.Application/Enrollments/Handlers/ReviewCourseCommandHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/ReviewCourseCommandHandler.cs
@@ -45,7 +45,7 @@ public sealed class ReviewCourseCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);

--- a/ELearning.Application/Enrollments/Handlers/StartLessonCommandHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/StartLessonCommandHandler.cs
@@ -40,7 +40,7 @@ public sealed class StartLessonCommandHandler(
 
         if (!course.ContainsLesson(request.LessonId))
         {
-            return Result.Failure("The lesson does not belong to the enrolled course.");
+            return Result.Failure(ApplicationError.Conflict("The lesson does not belong to the enrolled course."));
         }
 
         try
@@ -50,7 +50,7 @@ public sealed class StartLessonCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);

--- a/ELearning.Application/Enrollments/Handlers/UpdateEnrollmentStatusCommandHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/UpdateEnrollmentStatusCommandHandler.cs
@@ -47,16 +47,16 @@ public class UpdateEnrollmentStatusCommandHandler(
             }
             else if (status.Equals("Completed", StringComparison.OrdinalIgnoreCase))
             {
-                return Result.Failure("Course completion is driven by lesson progression and cannot be set manually.");
+                return Result.Failure(ApplicationError.Conflict("Course completion is driven by lesson progression and cannot be set manually."));
             }
             else
             {
-                return Result.Failure("Invalid status value.");
+                return Result.Failure(ApplicationError.BadRequest("Invalid status value."));
             }
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);

--- a/ELearning.Application/Submissions/Handlers/CreateSubmissionCommandHandler.cs
+++ b/ELearning.Application/Submissions/Handlers/CreateSubmissionCommandHandler.cs
@@ -43,7 +43,7 @@ public class CreateSubmissionCommandHandler(
 
         if (!course.ContainsAssignment(request.AssignmentId))
         {
-            return Result.Failure("The assessment does not belong to the enrolled course.");
+            return Result.Failure(ApplicationError.Conflict("The assessment does not belong to the enrolled course."));
         }
 
         var enrollment = await enrollmentRepository.GetByStudentAndCourseIdAsync(studentId, module.CourseId, cancellationToken)
@@ -62,7 +62,7 @@ public class CreateSubmissionCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);

--- a/ELearning.Application/Submissions/Handlers/GradeSubmissionCommandHandler.cs
+++ b/ELearning.Application/Submissions/Handlers/GradeSubmissionCommandHandler.cs
@@ -40,7 +40,7 @@ public class GradeSubmissionCommandHandler(
 
         if (submission.IsGraded)
         {
-            return Result.Failure("Submission is already graded.");
+            return Result.Failure(ApplicationError.Conflict("Submission is already graded."));
         }
 
         // Get the assignment to check max points
@@ -70,7 +70,7 @@ public class GradeSubmissionCommandHandler(
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException)
         {
-            return Result.Failure(ex.Message);
+            return Result.Failure(ApplicationError.Conflict(ex.Message));
         }
 
         await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);

--- a/ELearning.IntegrationTests/ApiErrorContractIntegrationTests.cs
+++ b/ELearning.IntegrationTests/ApiErrorContractIntegrationTests.cs
@@ -1,0 +1,297 @@
+// <copyright file="ApiErrorContractIntegrationTests.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.IntegrationTests;
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using ELearning.Application.Auth.Abstractions;
+using ELearning.Domain.Entities.CourseAggregate.Enums;
+using ELearning.Domain.Entities.UserAggregate;
+using ELearning.Domain.ValueObjects;
+using ELearning.Infrastructure.Data;
+using ELearning.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+public sealed class ApiErrorContractIntegrationTests : IClassFixture<RealAuthWebApplicationFactory>
+{
+    private const string JwtIssuer = "integration-tests";
+    private const string JwtAudience = "integration-tests";
+    private const string JwtSecret = "integration-tests-secret-key-with-32chars";
+
+    private readonly RealAuthWebApplicationFactory factory;
+    private readonly HttpClient client;
+
+    public ApiErrorContractIntegrationTests(RealAuthWebApplicationFactory factory)
+    {
+        this.factory = factory;
+        this.client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ValidationFailure_ReturnsValidationProblemDetailsWithStableCode()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var instructorId = await this.SeedInstructorAsync(cancellationToken);
+
+        var response = await this.PostAsRoleAsync(
+            "/api/courses",
+            new
+            {
+                Title = string.Empty,
+                Description = string.Empty,
+                CategoryId = 0,
+                LevelId = 0,
+                Price = -1m,
+                DurationHours = -1,
+                DurationMinutes = 60,
+            },
+            instructorId,
+            "Instructor",
+            cancellationToken);
+
+        using var problem = await AssertProblemAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "validation.failed",
+            "Validation failed",
+            cancellationToken);
+
+        problem.RootElement.GetProperty("errors").TryGetProperty("Title", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task MissingResource_ReturnsNotFoundProblemDetailsWithStableCode()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var response = await this.client.GetAsync($"/api/courses/{Guid.NewGuid()}", cancellationToken);
+
+        using var problem = await AssertProblemAsync(
+            response,
+            HttpStatusCode.NotFound,
+            "resource.not_found",
+            "Resource not found",
+            cancellationToken);
+    }
+
+    [Fact]
+    public async Task BusinessRuleFailure_ReturnsConflictProblemDetailsWithStableCode()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var instructorId = await this.SeedInstructorAsync(cancellationToken);
+        var courseId = await this.CreateCourseAsync(instructorId, cancellationToken);
+
+        var response = await this.PostAsRoleAsync(
+            $"/api/courses/{courseId}/submit-for-review",
+            null,
+            instructorId,
+            "Instructor",
+            cancellationToken);
+
+        using var problem = await AssertProblemAsync(
+            response,
+            HttpStatusCode.Conflict,
+            "conflict.business_rule",
+            "Conflict",
+            cancellationToken);
+    }
+
+    [Fact]
+    public async Task RouteIdMismatch_ReturnsBadRequestProblemDetailsWithStableCode()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var instructorId = await this.SeedInstructorAsync(cancellationToken);
+        var routeCourseId = Guid.NewGuid();
+        var payloadCourseId = Guid.NewGuid();
+
+        var response = await this.PutAsRoleAsync(
+            $"/api/courses/{routeCourseId}",
+            new
+            {
+                CourseId = payloadCourseId,
+                Title = "Route mismatch course",
+                Description = "A valid payload that should fail before reaching the handler.",
+                CategoryId = CourseCategory.Programming.Id,
+                LevelId = CourseLevel.Beginner.Id,
+                Price = 0m,
+                DurationHours = 1,
+                DurationMinutes = 0,
+                IsFeatured = false,
+            },
+            instructorId,
+            "Instructor",
+            cancellationToken);
+
+        using var problem = await AssertProblemAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "request.route_id_mismatch",
+            "Invalid request",
+            cancellationToken);
+    }
+
+    [Fact]
+    public async Task MissingToken_ReturnsUnauthorizedProblemDetailsWithStableCode()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var response = await this.client.GetAsync($"/api/students/{Guid.NewGuid()}/progress", cancellationToken);
+
+        using var problem = await AssertProblemAsync(
+            response,
+            HttpStatusCode.Unauthorized,
+            "authentication.unauthorized",
+            "Unauthorized",
+            cancellationToken);
+    }
+
+    [Fact]
+    public async Task WrongRole_ReturnsForbiddenProblemDetailsWithStableCode()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/api/instructors/{Guid.NewGuid()}/pending-submissions");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt(Guid.NewGuid(), "Student"));
+
+        var response = await this.client.SendAsync(request, cancellationToken);
+
+        using var problem = await AssertProblemAsync(
+            response,
+            HttpStatusCode.Forbidden,
+            "authorization.forbidden",
+            "Forbidden",
+            cancellationToken);
+    }
+
+    private async Task<Guid> CreateCourseAsync(Guid instructorId, CancellationToken cancellationToken)
+    {
+        var title = $"API error contract {Guid.NewGuid():N}";
+        var response = await this.PostAsRoleAsync(
+            "/api/courses",
+            new
+            {
+                Title = title,
+                Description = "A course created for API error contract tests.",
+                CategoryId = CourseCategory.Programming.Id,
+                LevelId = CourseLevel.Beginner.Id,
+                Price = 0m,
+                DurationHours = 1,
+                DurationMinutes = 0,
+            },
+            instructorId,
+            "Instructor",
+            cancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var course = await dbContext.Courses.SingleAsync(course => course.Title == title, cancellationToken);
+        return course.Id;
+    }
+
+    private async Task<HttpResponseMessage> PostAsRoleAsync(
+        string requestUri,
+        object? payload,
+        Guid userId,
+        string role,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+        {
+            Content = payload is null ? null : JsonContent.Create(payload),
+        };
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt(userId, role));
+        return await this.client.SendAsync(request, cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> PutAsRoleAsync(
+        string requestUri,
+        object payload,
+        Guid userId,
+        string role,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, requestUri)
+        {
+            Content = JsonContent.Create(payload),
+        };
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwt(userId, role));
+        return await this.client.SendAsync(request, cancellationToken);
+    }
+
+    private async Task<Guid> SeedInstructorAsync(CancellationToken cancellationToken)
+    {
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
+        var uniqueValue = Guid.NewGuid().ToString("N");
+
+        var instructor = new Instructor(
+            firstName: "API",
+            lastName: "Tester",
+            email: Email.Create($"api.error.{uniqueValue}@tests.io"),
+            passwordHash: passwordHasher.HashPassword("P@ssword123!"),
+            bio: "Validates API error contracts.",
+            expertise: "Backend engineering");
+
+        dbContext.Instructors.Add(instructor);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return instructor.Id;
+    }
+
+    private static async Task<JsonDocument> AssertProblemAsync(
+        HttpResponseMessage response,
+        HttpStatusCode statusCode,
+        string code,
+        string title,
+        CancellationToken cancellationToken)
+    {
+        response.StatusCode.Should().Be(statusCode);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var problem = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken);
+
+        problem.RootElement.GetProperty("status").GetInt32().Should().Be((int)statusCode);
+        problem.RootElement.GetProperty("title").GetString().Should().Be(title);
+        problem.RootElement.GetProperty("code").GetString().Should().Be(code);
+        problem.RootElement.GetProperty("traceId").GetString().Should().NotBeNullOrWhiteSpace();
+
+        return problem;
+    }
+
+    private static string CreateJwt(Guid userId, string role)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+            new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new Claim(ClaimTypes.Role, role),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: JwtIssuer,
+            audience: JwtAudience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/ELearning.IntegrationTests/CourseAuthoringWorkflowIntegrationTests.cs
+++ b/ELearning.IntegrationTests/CourseAuthoringWorkflowIntegrationTests.cs
@@ -59,7 +59,7 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
     }
 
     [Fact]
-    public async Task CourseCannotBeSubmittedWithoutContent_ReturnsBadRequest()
+    public async Task CourseCannotBeSubmittedWithoutContent_ReturnsConflict()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var instructorId = await this.SeedInstructorAsync(cancellationToken);
@@ -72,7 +72,7 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
             "Instructor",
             cancellationToken);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     [Fact]

--- a/ELearning.IntegrationTests/GlobalExceptionMiddlewareTests.cs
+++ b/ELearning.IntegrationTests/GlobalExceptionMiddlewareTests.cs
@@ -33,5 +33,6 @@ public sealed class GlobalExceptionMiddlewareTests
         using var payload = await JsonDocument.ParseAsync(context.Response.Body, cancellationToken: cancellationToken);
         payload.RootElement.GetProperty("status").GetInt32().Should().Be(StatusCodes.Status409Conflict);
         payload.RootElement.GetProperty("title").GetString().Should().Be("Concurrency conflict");
+        payload.RootElement.GetProperty("code").GetString().Should().Be("conflict.concurrency");
     }
 }


### PR DESCRIPTION
## Summary
- Added typed ApplicationError and ErrorType with stable error codes.
- Centralized REST error mapping in ApiControllerBase.
- Added consistent ProblemDetails generation via ApiProblemDetailsFactory.
- Updated middleware, MVC validation, and JWT 401/403 responses to include stable code and traceId.
- Removed fragile string-based StartsWith(...) controller checks.
- Added integration tests for API error contracts.

## Validation
- dotnet restore ELearning.sln passed
- dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false passed with 0 warnings
- dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false passed: 110 application tests and 35 integration tests
- dotnet list ELearning.sln package --vulnerable --include-transitive reports no vulnerable packages

## Postponed
- GraphQL error contract redesign
- Broad command-to-request DTO replacement
- OpenAPI documentation polish