### PR TITLE
Add RabbitMQ notification consumer and idempotent processing

### DIFF
--- a/ELearning.API/appsettings.Development.json
+++ b/ELearning.API/appsettings.Development.json
@@ -19,6 +19,9 @@
     "Password": "guest",
     "VirtualHost": "/",
     "ExchangeName": "elearning.integration.events",
+    "NotificationQueueName": "elearning.notifications.email",
+    "DeadLetterExchangeName": "elearning.integration.dead-letter",
+    "DeadLetterQueueName": "elearning.notifications.email.dead-letter",
     "PublisherConfirmTimeoutSeconds": 5
   },
   "Logging": {

--- a/ELearning.API/appsettings.json
+++ b/ELearning.API/appsettings.json
@@ -19,6 +19,9 @@
     "Password": "guest",
     "VirtualHost": "/",
     "ExchangeName": "elearning.integration.events",
+    "NotificationQueueName": "elearning.notifications.email",
+    "DeadLetterExchangeName": "elearning.integration.dead-letter",
+    "DeadLetterQueueName": "elearning.notifications.email.dead-letter",
     "PublisherConfirmTimeoutSeconds": 5
   },
   "Logging": {

--- a/ELearning.Application.Tests/Certificates/CertificateIssuanceCoordinatorTests.cs
+++ b/ELearning.Application.Tests/Certificates/CertificateIssuanceCoordinatorTests.cs
@@ -22,7 +22,7 @@ public sealed class CertificateIssuanceCoordinatorTests
     public async Task TryIssueForCompletedEnrollmentAsync_WhenEnrollmentIsNotCompleted_ReturnsNull()
     {
         var student = CreateStudent();
-        var coordinator = CreateCoordinator(student, out _, out var emailService);
+        var coordinator = CreateCoordinator(student, out _, out var notificationRequestService);
         var course = CreateCourse();
         var enrollment = new Enrollment(student.Id, course.Id);
 
@@ -32,14 +32,14 @@ public sealed class CertificateIssuanceCoordinatorTests
             TestContext.Current.CancellationToken);
 
         certificate.Should().BeNull();
-        emailService.CertificateEmailsSent.Should().Be(0);
+        notificationRequestService.CertificateNotificationsRequested.Should().Be(0);
     }
 
     [Fact]
     public async Task TryIssueForCompletedEnrollmentAsync_WhenCalledTwice_IssuesOnlyOneCertificate()
     {
         var student = CreateStudent();
-        var coordinator = CreateCoordinator(student, out var repository, out var emailService);
+        var coordinator = CreateCoordinator(student, out var repository, out var notificationRequestService);
         var course = CreateCourse();
         var enrollment = new Enrollment(student.Id, course.Id);
         enrollment.CompleteLesson(Guid.NewGuid(), totalLessonsInCourse: 1, requiredAssignmentIds: []);
@@ -58,19 +58,19 @@ public sealed class CertificateIssuanceCoordinatorTests
         secondCertificate.Should().NotBeNull();
         secondCertificate!.Id.Should().Be(firstCertificate!.Id);
         repository.StoredCertificates.Should().ContainSingle();
-        emailService.CertificateEmailsSent.Should().Be(1);
+        notificationRequestService.CertificateNotificationsRequested.Should().Be(1);
     }
 
     private static CertificateIssuanceCoordinator CreateCoordinator(
         Student student,
         out InMemoryCertificateRepository certificateRepository,
-        out FakeEmailService emailService)
+        out FakeNotificationRequestService notificationRequestService)
     {
         certificateRepository = new InMemoryCertificateRepository();
-        emailService = new FakeEmailService();
+        notificationRequestService = new FakeNotificationRequestService();
         var userRepository = new InMemoryUserRepository(student);
 
-        return new CertificateIssuanceCoordinator(certificateRepository, userRepository, emailService);
+        return new CertificateIssuanceCoordinator(certificateRepository, userRepository, notificationRequestService);
     }
 
     private static Student CreateStudent() =>
@@ -140,23 +140,49 @@ public sealed class CertificateIssuanceCoordinatorTests
         public Task<int> GetUsersCountAsync(CancellationToken cancellationToken = default) => Task.FromResult(1);
     }
 
-    private sealed class FakeEmailService : IEmailService
+    private sealed class FakeNotificationRequestService : INotificationRequestService
     {
-        public int CertificateEmailsSent { get; private set; }
+        public int CertificateNotificationsRequested { get; private set; }
 
-        public Task SendEmailAsync(string to, string subject, string body, bool isHtml = false) => Task.CompletedTask;
+        public Task RequestEnrollmentConfirmationAsync(
+            string recipientEmail,
+            string studentName,
+            string courseName,
+            Guid sourceId,
+            CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task SendEnrollmentConfirmationAsync(string to, string studentName, string courseName) => Task.CompletedTask;
+        public Task RequestAssignmentGradedAsync(
+            string recipientEmail,
+            string studentName,
+            string assignmentName,
+            int score,
+            Guid sourceId,
+            CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task SendAssignmentGradedAsync(string to, string studentName, string assignmentName, int score) => Task.CompletedTask;
+        public Task RequestCourseApprovedAsync(
+            string recipientEmail,
+            string instructorName,
+            string courseName,
+            Guid sourceId,
+            CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task SendCourseApprovedAsync(string to, string instructorName, string courseName) => Task.CompletedTask;
+        public Task RequestCourseRejectedAsync(
+            string recipientEmail,
+            string instructorName,
+            string courseName,
+            string reason,
+            Guid sourceId,
+            CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task SendCourseRejectedAsync(string to, string instructorName, string courseName, string reason) => Task.CompletedTask;
-
-        public Task SendCertificateIssuedAsync(string to, string studentName, string courseName, string certificateCode)
+        public Task RequestCertificateIssuedAsync(
+            string recipientEmail,
+            string studentName,
+            string courseName,
+            string certificateCode,
+            Guid sourceId,
+            CancellationToken cancellationToken)
         {
-            this.CertificateEmailsSent++;
+            this.CertificateNotificationsRequested++;
             return Task.CompletedTask;
         }
     }

--- a/ELearning.Application/Certificates/Services/CertificateIssuanceCoordinator.cs
+++ b/ELearning.Application/Certificates/Services/CertificateIssuanceCoordinator.cs
@@ -15,7 +15,7 @@ using ELearning.Domain.Entities.UserAggregate.Abstractions.Repositories;
 public sealed class CertificateIssuanceCoordinator(
         ICertificateRepository certificateRepository,
         IUserRepository userRepository,
-        IEmailService emailService)
+        INotificationRequestService notificationRequestService)
 {
     public async Task<Certificate?> TryIssueForCompletedEnrollmentAsync(
         Enrollment enrollment,
@@ -47,11 +47,13 @@ public sealed class CertificateIssuanceCoordinator(
         var student = await userRepository.GetByIdForUpdateAsync(enrollment.StudentId, cancellationToken)
             ?? throw new InvalidOperationException("Completed enrollment is associated with a missing student.");
 
-        await emailService.SendCertificateIssuedAsync(
+        await notificationRequestService.RequestCertificateIssuedAsync(
             student.Email.Value,
             student.FullName,
             course.Title,
-            certificate.CertificateCode);
+            certificate.CertificateCode,
+            certificate.Id,
+            cancellationToken);
 
         return certificate;
     }

--- a/ELearning.Application/Common/Interfaces/INotificationRequestService.cs
+++ b/ELearning.Application/Common/Interfaces/INotificationRequestService.cs
@@ -1,0 +1,46 @@
+// <copyright file="INotificationRequestService.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Application.Common.Interfaces;
+
+public interface INotificationRequestService
+{
+    Task RequestEnrollmentConfirmationAsync(
+        string recipientEmail,
+        string studentName,
+        string courseName,
+        Guid sourceId,
+        CancellationToken cancellationToken);
+
+    Task RequestAssignmentGradedAsync(
+        string recipientEmail,
+        string studentName,
+        string assignmentName,
+        int score,
+        Guid sourceId,
+        CancellationToken cancellationToken);
+
+    Task RequestCourseApprovedAsync(
+        string recipientEmail,
+        string instructorName,
+        string courseName,
+        Guid sourceId,
+        CancellationToken cancellationToken);
+
+    Task RequestCourseRejectedAsync(
+        string recipientEmail,
+        string instructorName,
+        string courseName,
+        string reason,
+        Guid sourceId,
+        CancellationToken cancellationToken);
+
+    Task RequestCertificateIssuedAsync(
+        string recipientEmail,
+        string studentName,
+        string courseName,
+        string certificateCode,
+        Guid sourceId,
+        CancellationToken cancellationToken);
+}

--- a/ELearning.Application/Courses/Handlers/ApproveCoursePublicationCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/ApproveCoursePublicationCommandHandler.cs
@@ -17,7 +17,7 @@ using MediatR;
 public sealed class ApproveCoursePublicationCommandHandler(
         ICourseRepository courseRepository,
         IUserRepository userRepository,
-        IEmailService emailService,
+        INotificationRequestService notificationRequestService,
         ICurrentUserService currentUserService)
     : IRequestHandler<ApproveCoursePublicationCommand, Result>
 {
@@ -45,10 +45,12 @@ public sealed class ApproveCoursePublicationCommandHandler(
         var instructor = await userRepository.GetByIdForUpdateAsync(course.InstructorId, cancellationToken)
             ?? throw new NotFoundException(nameof(User), course.InstructorId);
 
-        await emailService.SendCourseApprovedAsync(
+        await notificationRequestService.RequestCourseApprovedAsync(
             instructor.Email.Value,
             instructor.FullName,
-            course.Title);
+            course.Title,
+            course.Id,
+            cancellationToken);
 
         return Result.Success();
     }

--- a/ELearning.Application/Courses/Handlers/RejectCoursePublicationCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/RejectCoursePublicationCommandHandler.cs
@@ -17,7 +17,7 @@ using MediatR;
 public sealed class RejectCoursePublicationCommandHandler(
         ICourseRepository courseRepository,
         IUserRepository userRepository,
-        IEmailService emailService,
+        INotificationRequestService notificationRequestService,
         ICurrentUserService currentUserService)
     : IRequestHandler<RejectCoursePublicationCommand, Result>
 {
@@ -45,11 +45,13 @@ public sealed class RejectCoursePublicationCommandHandler(
         var instructor = await userRepository.GetByIdForUpdateAsync(course.InstructorId, cancellationToken)
             ?? throw new NotFoundException(nameof(User), course.InstructorId);
 
-        await emailService.SendCourseRejectedAsync(
+        await notificationRequestService.RequestCourseRejectedAsync(
             instructor.Email.Value,
             instructor.FullName,
             course.Title,
-            course.RejectionReason ?? request.Reason);
+            course.RejectionReason ?? request.Reason,
+            course.Id,
+            cancellationToken);
 
         return Result.Success();
     }

--- a/ELearning.Application/Enrollments/Handlers/CreateEnrollmentCommandHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/CreateEnrollmentCommandHandler.cs
@@ -20,7 +20,7 @@ public class CreateEnrollmentCommandHandler(
             IUserRepository userRepository,
             ICourseRepository courseRepository,
             IEnrollmentRepository enrollmentRepository,
-            IEmailService emailService,
+            INotificationRequestService notificationRequestService,
             ICurrentUserService currentUserService)
     : IRequestHandler<CreateEnrollmentCommand, Result>
 {
@@ -59,7 +59,12 @@ public class CreateEnrollmentCommandHandler(
 
         var enrollment = new Enrollment(studentId, course.Id);
         await enrollmentRepository.AddAsync(enrollment, cancellationToken);
-        await emailService.SendEnrollmentConfirmationAsync(student.Email.Value, student.FullName, course.Title);
+        await notificationRequestService.RequestEnrollmentConfirmationAsync(
+            student.Email.Value,
+            student.FullName,
+            course.Title,
+            enrollment.Id,
+            cancellationToken);
 
         return Result.Success();
     }

--- a/ELearning.Application/Submissions/Handlers/GradeSubmissionCommandHandler.cs
+++ b/ELearning.Application/Submissions/Handlers/GradeSubmissionCommandHandler.cs
@@ -21,7 +21,7 @@ public class GradeSubmissionCommandHandler(
         IAssignmentReadRepository assignmentRepository,
         ICourseRepository courseRepository,
         IUserRepository userRepository,
-        IEmailService emailService,
+        INotificationRequestService notificationRequestService,
         ICurrentUserService currentUserService)
     : IRequestHandler<GradeSubmissionCommand, Result>
 {
@@ -78,11 +78,13 @@ public class GradeSubmissionCommandHandler(
         var student = await userRepository.GetByIdForUpdateAsync(enrollment.StudentId, cancellationToken)
             ?? throw new NotFoundException(nameof(User), enrollment.StudentId);
 
-        await emailService.SendAssignmentGradedAsync(
+        await notificationRequestService.RequestAssignmentGradedAsync(
             student.Email.Value,
             student.FullName,
             assignment.Title,
-            request.Score);
+            request.Score,
+            submission.Id,
+            cancellationToken);
 
         return Result.Success();
     }

--- a/ELearning.Infrastructure/Data/ApplicationDbContext.cs
+++ b/ELearning.Infrastructure/Data/ApplicationDbContext.cs
@@ -54,6 +54,8 @@ public class ApplicationDbContext : DbContext
 
     public DbSet<OutboxMessage> OutboxMessages { get; set; } = null!;
 
+    public DbSet<ProcessedIntegrationMessage> ProcessedIntegrationMessages { get; set; } = null!;
+
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
         this.UpdateSqliteConcurrencyTokens();

--- a/ELearning.Infrastructure/Data/Configurations/ProcessedIntegrationMessageConfiguration.cs
+++ b/ELearning.Infrastructure/Data/Configurations/ProcessedIntegrationMessageConfiguration.cs
@@ -1,0 +1,30 @@
+// <copyright file="ProcessedIntegrationMessageConfiguration.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Data.Configurations;
+
+using ELearning.Infrastructure.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public sealed class ProcessedIntegrationMessageConfiguration : IEntityTypeConfiguration<ProcessedIntegrationMessage>
+{
+    public void Configure(EntityTypeBuilder<ProcessedIntegrationMessage> builder)
+    {
+        builder.HasKey(x => new { x.MessageId, x.Consumer });
+
+        builder.Property(x => x.Consumer)
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(x => x.Type)
+            .HasMaxLength(512)
+            .IsRequired();
+
+        builder.Property(x => x.Error)
+            .HasMaxLength(4096);
+
+        builder.HasIndex(x => x.ProcessedOnUtc);
+    }
+}

--- a/ELearning.Infrastructure/Data/Migrations/20260522221441_AddProcessedIntegrationMessages.Designer.cs
+++ b/ELearning.Infrastructure/Data/Migrations/20260522221441_AddProcessedIntegrationMessages.Designer.cs
@@ -4,6 +4,7 @@ using ELearning.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ELearning.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522221441_AddProcessedIntegrationMessages")]
+    partial class AddProcessedIntegrationMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ELearning.Infrastructure/Data/Migrations/20260522221441_AddProcessedIntegrationMessages.cs
+++ b/ELearning.Infrastructure/Data/Migrations/20260522221441_AddProcessedIntegrationMessages.cs
@@ -1,0 +1,45 @@
+// <copyright file="20260522221441_AddProcessedIntegrationMessages.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Data.Migrations;
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+/// <inheritdoc />
+public partial class AddProcessedIntegrationMessages : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "ProcessedIntegrationMessages",
+            columns: table => new
+            {
+                MessageId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Consumer = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                Type = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                ProcessedOnUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                Error = table.Column<string>(type: "nvarchar(max)", maxLength: 4096, nullable: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ProcessedIntegrationMessages", x => new { x.MessageId, x.Consumer });
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ProcessedIntegrationMessages_ProcessedOnUtc",
+            table: "ProcessedIntegrationMessages",
+            column: "ProcessedOnUtc");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "ProcessedIntegrationMessages");
+    }
+}

--- a/ELearning.Infrastructure/Data/Models/ProcessedIntegrationMessage.cs
+++ b/ELearning.Infrastructure/Data/Models/ProcessedIntegrationMessage.cs
@@ -1,0 +1,18 @@
+// <copyright file="ProcessedIntegrationMessage.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Data.Models;
+
+public sealed class ProcessedIntegrationMessage
+{
+    public Guid MessageId { get; set; }
+
+    public string Consumer { get; set; } = string.Empty;
+
+    public string Type { get; set; } = string.Empty;
+
+    public DateTime ProcessedOnUtc { get; set; }
+
+    public string? Error { get; set; }
+}

--- a/ELearning.Infrastructure/DependencyInjection.cs
+++ b/ELearning.Infrastructure/DependencyInjection.cs
@@ -17,6 +17,7 @@ using ELearning.Domain.Entities.EnrollmentAggregate.Abstractions.Repositories;
 using ELearning.Domain.Entities.UserAggregate.Abstractions.Repositories;
 using ELearning.Infrastructure.Data;
 using ELearning.Infrastructure.Data.Repositories;
+using ELearning.Infrastructure.Notifications;
 using ELearning.Infrastructure.Options;
 using ELearning.Infrastructure.Outbox;
 using ELearning.Infrastructure.Services;
@@ -93,6 +94,7 @@ public static class DependencyInjection
 
         services.AddTransient<IDateTime, DateTimeService>();
         services.AddTransient<IEmailService, EmailService>();
+        services.AddScoped<INotificationRequestService, NotificationRequestService>();
         services.AddTransient<IFileStorageService, FileStorageService>();
         services.AddScoped<IAccessTokenIssuer, AccessTokenIssuer>();
         services.AddScoped<IRefreshTokenStore, RefreshTokenStore>();
@@ -103,10 +105,12 @@ public static class DependencyInjection
         services.AddScoped<ICurrentUserService, CurrentUserService>();
 
         services.AddSingleton<IOutboxIntegrationEventMapper, OutboxIntegrationEventMapper>();
+        services.AddScoped<INotificationIntegrationEventHandler, NotificationIntegrationEventHandler>();
         if (rabbitMqOptions.Enabled)
         {
             services.AddSingleton<IIntegrationEventPublisher, RabbitMqIntegrationEventPublisher>();
             services.AddHostedService<OutboxDispatcherHostedService>();
+            services.AddHostedService<RabbitMqNotificationConsumerHostedService>();
         }
         else
         {

--- a/ELearning.Infrastructure/Notifications/INotificationIntegrationEventHandler.cs
+++ b/ELearning.Infrastructure/Notifications/INotificationIntegrationEventHandler.cs
@@ -1,0 +1,14 @@
+// <copyright file="INotificationIntegrationEventHandler.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Notifications;
+
+public interface INotificationIntegrationEventHandler
+{
+    Task<NotificationProcessingResult> HandleAsync(
+        Guid messageId,
+        string eventType,
+        string payload,
+        CancellationToken cancellationToken);
+}

--- a/ELearning.Infrastructure/Notifications/NotificationIntegrationEventHandler.cs
+++ b/ELearning.Infrastructure/Notifications/NotificationIntegrationEventHandler.cs
@@ -1,0 +1,93 @@
+// <copyright file="NotificationIntegrationEventHandler.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Notifications;
+
+using System.Text.Json;
+using ELearning.Application.Common.Interfaces;
+using ELearning.Infrastructure.Data;
+using ELearning.Infrastructure.Data.Models;
+using ELearning.Infrastructure.Outbox;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+public sealed class NotificationIntegrationEventHandler(
+    ApplicationDbContext dbContext,
+    IEmailService emailService,
+    ILogger<NotificationIntegrationEventHandler> logger) : INotificationIntegrationEventHandler
+{
+    public const string ConsumerName = "email-notification-consumer";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<NotificationProcessingResult> HandleAsync(
+        Guid messageId,
+        string eventType,
+        string payload,
+        CancellationToken cancellationToken)
+    {
+        if (!IsNotificationRequested(eventType))
+        {
+            throw new InvalidOperationException($"Unsupported notification integration event type '{eventType}'.");
+        }
+
+        var integrationEvent = JsonSerializer.Deserialize<NotificationRequestedIntegrationEvent>(payload, JsonOptions)
+            ?? throw new InvalidOperationException("Notification integration event payload could not be deserialized.");
+
+        var effectiveMessageId = messageId == Guid.Empty ? integrationEvent.EventId : messageId;
+        var alreadyProcessed = await dbContext.ProcessedIntegrationMessages
+            .AnyAsync(
+                x => x.MessageId == effectiveMessageId && x.Consumer == ConsumerName,
+                cancellationToken);
+
+        if (alreadyProcessed)
+        {
+            logger.LogInformation(
+                "Skipping duplicate notification message {MessageId} for consumer {Consumer}.",
+                effectiveMessageId,
+                ConsumerName);
+            return NotificationProcessingResult.AlreadyProcessed;
+        }
+
+        await emailService.SendEmailAsync(
+            integrationEvent.RecipientEmail,
+            integrationEvent.Subject,
+            integrationEvent.Body,
+            integrationEvent.IsHtml);
+
+        dbContext.ProcessedIntegrationMessages.Add(new ProcessedIntegrationMessage
+        {
+            MessageId = effectiveMessageId,
+            Consumer = ConsumerName,
+            Type = nameof(NotificationRequestedIntegrationEvent),
+            ProcessedOnUtc = DateTime.UtcNow,
+        });
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            logger.LogInformation(
+                ex,
+                "Notification message {MessageId} was already recorded as processed by another consumer.",
+                effectiveMessageId);
+
+            dbContext.ChangeTracker.Clear();
+            return NotificationProcessingResult.AlreadyProcessed;
+        }
+
+        return NotificationProcessingResult.Processed;
+    }
+
+    private static bool IsNotificationRequested(string eventType) =>
+        eventType.Equals(nameof(NotificationRequestedIntegrationEvent), StringComparison.Ordinal) ||
+        eventType.EndsWith($".{nameof(NotificationRequestedIntegrationEvent)}", StringComparison.Ordinal);
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException exception) =>
+        exception.InnerException?.Message.Contains("UNIQUE", StringComparison.OrdinalIgnoreCase) == true ||
+        exception.InnerException?.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase) == true ||
+        exception.InnerException?.Message.Contains("PK_", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/ELearning.Infrastructure/Notifications/NotificationProcessingResult.cs
+++ b/ELearning.Infrastructure/Notifications/NotificationProcessingResult.cs
@@ -1,0 +1,11 @@
+// <copyright file="NotificationProcessingResult.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Notifications;
+
+public enum NotificationProcessingResult
+{
+    Processed,
+    AlreadyProcessed,
+}

--- a/ELearning.Infrastructure/Notifications/NotificationRequestService.cs
+++ b/ELearning.Infrastructure/Notifications/NotificationRequestService.cs
@@ -1,0 +1,175 @@
+// <copyright file="NotificationRequestService.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Notifications;
+
+using System.Text.Json;
+using ELearning.Application.Common.Interfaces;
+using ELearning.Infrastructure.Data;
+using ELearning.Infrastructure.Data.Models;
+using ELearning.Infrastructure.Options;
+using ELearning.Infrastructure.Outbox;
+using Microsoft.Extensions.Options;
+
+public sealed class NotificationRequestService(
+    ApplicationDbContext dbContext,
+    IEmailService emailService,
+    IOptions<RabbitMqOptions> rabbitMqOptions) : INotificationRequestService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly RabbitMqOptions options = rabbitMqOptions.Value;
+
+    public Task RequestEnrollmentConfirmationAsync(
+        string recipientEmail,
+        string studentName,
+        string courseName,
+        Guid sourceId,
+        CancellationToken cancellationToken)
+    {
+        var subject = $"Welcome to {courseName}";
+        var body = $"Dear {studentName},\n\nThank you for enrolling in {courseName}. We hope you enjoy the course!\n\nBest regards,\nE-Learning Team";
+
+        return this.RequestAsync(
+            notificationType: "enrollment.confirmation",
+            recipientEmail,
+            recipientName: studentName,
+            subject,
+            body,
+            source: "Enrollment",
+            sourceId,
+            fallback: () => emailService.SendEnrollmentConfirmationAsync(recipientEmail, studentName, courseName),
+            cancellationToken);
+    }
+
+    public Task RequestAssignmentGradedAsync(
+        string recipientEmail,
+        string studentName,
+        string assignmentName,
+        int score,
+        Guid sourceId,
+        CancellationToken cancellationToken)
+    {
+        var subject = $"Your assignment {assignmentName} has been graded";
+        var body = $"Dear {studentName},\n\nYour assignment {assignmentName} has been graded. You received {score} points.\n\nBest regards,\nE-Learning Team";
+
+        return this.RequestAsync(
+            notificationType: "assignment.graded",
+            recipientEmail,
+            recipientName: studentName,
+            subject,
+            body,
+            source: "Submission",
+            sourceId,
+            fallback: () => emailService.SendAssignmentGradedAsync(recipientEmail, studentName, assignmentName, score),
+            cancellationToken);
+    }
+
+    public Task RequestCourseApprovedAsync(
+        string recipientEmail,
+        string instructorName,
+        string courseName,
+        Guid sourceId,
+        CancellationToken cancellationToken)
+    {
+        var subject = $"{courseName} is now published";
+        var body = $"Dear {instructorName},\n\nYour course {courseName} has been approved and published.\n\nBest regards,\nE-Learning Team";
+
+        return this.RequestAsync(
+            notificationType: "course.approved",
+            recipientEmail,
+            recipientName: instructorName,
+            subject,
+            body,
+            source: "Course",
+            sourceId,
+            fallback: () => emailService.SendCourseApprovedAsync(recipientEmail, instructorName, courseName),
+            cancellationToken);
+    }
+
+    public Task RequestCourseRejectedAsync(
+        string recipientEmail,
+        string instructorName,
+        string courseName,
+        string reason,
+        Guid sourceId,
+        CancellationToken cancellationToken)
+    {
+        var subject = $"{courseName} needs changes before publication";
+        var body = $"Dear {instructorName},\n\nYour course {courseName} was rejected during review.\nReason: {reason}\n\nYou can update the course and resubmit it for review.\n\nBest regards,\nE-Learning Team";
+
+        return this.RequestAsync(
+            notificationType: "course.rejected",
+            recipientEmail,
+            recipientName: instructorName,
+            subject,
+            body,
+            source: "Course",
+            sourceId,
+            fallback: () => emailService.SendCourseRejectedAsync(recipientEmail, instructorName, courseName, reason),
+            cancellationToken);
+    }
+
+    public Task RequestCertificateIssuedAsync(
+        string recipientEmail,
+        string studentName,
+        string courseName,
+        string certificateCode,
+        Guid sourceId,
+        CancellationToken cancellationToken)
+    {
+        var subject = $"Your certificate for {courseName} is ready";
+        var body = $"Dear {studentName},\n\nCongratulations on completing {courseName}.\nYour certificate code is {certificateCode}.\n\nBest regards,\nE-Learning Team";
+
+        return this.RequestAsync(
+            notificationType: "certificate.issued",
+            recipientEmail,
+            recipientName: studentName,
+            subject,
+            body,
+            source: "Certificate",
+            sourceId,
+            fallback: () => emailService.SendCertificateIssuedAsync(recipientEmail, studentName, courseName, certificateCode),
+            cancellationToken);
+    }
+
+    private Task RequestAsync(
+        string notificationType,
+        string recipientEmail,
+        string recipientName,
+        string subject,
+        string body,
+        string source,
+        Guid sourceId,
+        Func<Task> fallback,
+        CancellationToken cancellationToken)
+    {
+        if (!this.options.Enabled)
+        {
+            return fallback();
+        }
+
+        var integrationEvent = new NotificationRequestedIntegrationEvent(
+            Guid.NewGuid(),
+            notificationType,
+            recipientEmail,
+            recipientName,
+            subject,
+            body,
+            IsHtml: false,
+            source,
+            sourceId,
+            DateTime.UtcNow);
+
+        dbContext.OutboxMessages.Add(new OutboxMessage
+        {
+            Id = integrationEvent.EventId,
+            OccurredOnUtc = integrationEvent.OccurredOnUtc,
+            Type = nameof(NotificationRequestedIntegrationEvent),
+            Payload = JsonSerializer.Serialize(integrationEvent, JsonOptions),
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/ELearning.Infrastructure/Notifications/RabbitMqNotificationConsumerHostedService.cs
+++ b/ELearning.Infrastructure/Notifications/RabbitMqNotificationConsumerHostedService.cs
@@ -1,0 +1,150 @@
+// <copyright file="RabbitMqNotificationConsumerHostedService.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.Infrastructure.Notifications;
+
+using System.Text;
+using ELearning.Infrastructure.Options;
+using ELearning.Infrastructure.Outbox;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+public sealed class RabbitMqNotificationConsumerHostedService(
+    IServiceScopeFactory scopeFactory,
+    IOptions<RabbitMqOptions> rabbitMqOptions,
+    ILogger<RabbitMqNotificationConsumerHostedService> logger) : BackgroundService
+{
+    private readonly RabbitMqOptions options = rabbitMqOptions.Value;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var factory = new ConnectionFactory
+        {
+            HostName = this.options.HostName,
+            Port = this.options.Port,
+            UserName = this.options.UserName,
+            Password = this.options.Password,
+            VirtualHost = this.options.VirtualHost,
+            ClientProvidedName = "elearning-api-notification-consumer",
+            AutomaticRecoveryEnabled = true,
+            NetworkRecoveryInterval = TimeSpan.FromSeconds(5),
+        };
+
+        await using var connection = await factory.CreateConnectionAsync(stoppingToken);
+        await using var channel = await connection.CreateChannelAsync(cancellationToken: stoppingToken);
+
+        await this.DeclareTopologyAsync(channel, stoppingToken);
+
+        var consumer = new AsyncEventingBasicConsumer(channel);
+        consumer.ReceivedAsync += async (_, args) =>
+        {
+            await this.HandleReceivedAsync(channel, args, stoppingToken);
+        };
+
+        await channel.BasicConsumeAsync(
+            queue: this.options.NotificationQueueName,
+            autoAck: false,
+            consumer: consumer,
+            cancellationToken: stoppingToken);
+
+        logger.LogInformation(
+            "RabbitMQ notification consumer started for queue {QueueName}.",
+            this.options.NotificationQueueName);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan, stoppingToken);
+    }
+
+    private async Task HandleReceivedAsync(
+        IChannel channel,
+        BasicDeliverEventArgs args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var payload = Encoding.UTF8.GetString(args.Body.Span);
+            var eventType = args.BasicProperties.Type ?? nameof(NotificationRequestedIntegrationEvent);
+
+            if (!Guid.TryParse(args.BasicProperties.MessageId, out var messageId))
+            {
+                logger.LogWarning(
+                    "Rejecting notification message without a valid message id. Delivery tag: {DeliveryTag}",
+                    args.DeliveryTag);
+                await channel.BasicRejectAsync(args.DeliveryTag, requeue: false, cancellationToken);
+                return;
+            }
+
+            using var scope = scopeFactory.CreateScope();
+            var handler = scope.ServiceProvider.GetRequiredService<INotificationIntegrationEventHandler>();
+            await handler.HandleAsync(messageId, eventType, payload, cancellationToken);
+
+            await channel.BasicAckAsync(args.DeliveryTag, multiple: false, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to process RabbitMQ notification message with delivery tag {DeliveryTag}.",
+                args.DeliveryTag);
+
+            await channel.BasicRejectAsync(args.DeliveryTag, requeue: false, cancellationToken);
+        }
+    }
+
+    private async Task DeclareTopologyAsync(IChannel channel, CancellationToken cancellationToken)
+    {
+        await channel.ExchangeDeclareAsync(
+            exchange: this.options.ExchangeName,
+            type: ExchangeType.Topic,
+            durable: true,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.ExchangeDeclareAsync(
+            exchange: this.options.DeadLetterExchangeName,
+            type: ExchangeType.Direct,
+            durable: true,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueDeclareAsync(
+            queue: this.options.DeadLetterQueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueBindAsync(
+            queue: this.options.DeadLetterQueueName,
+            exchange: this.options.DeadLetterExchangeName,
+            routingKey: this.options.NotificationQueueName,
+            cancellationToken: cancellationToken);
+
+        var queueArguments = new Dictionary<string, object?>
+        {
+            ["x-dead-letter-exchange"] = this.options.DeadLetterExchangeName,
+            ["x-dead-letter-routing-key"] = this.options.NotificationQueueName,
+        };
+
+        await channel.QueueDeclareAsync(
+            queue: this.options.NotificationQueueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: queueArguments,
+            cancellationToken: cancellationToken);
+
+        await channel.QueueBindAsync(
+            queue: this.options.NotificationQueueName,
+            exchange: this.options.ExchangeName,
+            routingKey: OutboxIntegrationEventMapper.NotificationRequestedRoutingKey,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/ELearning.Infrastructure/Options/RabbitMqOptions.cs
+++ b/ELearning.Infrastructure/Options/RabbitMqOptions.cs
@@ -22,5 +22,11 @@ public sealed class RabbitMqOptions
 
     public string ExchangeName { get; init; } = "elearning.integration.events";
 
+    public string NotificationQueueName { get; init; } = "elearning.notifications.email";
+
+    public string DeadLetterExchangeName { get; init; } = "elearning.integration.dead-letter";
+
+    public string DeadLetterQueueName { get; init; } = "elearning.notifications.email.dead-letter";
+
     public int PublisherConfirmTimeoutSeconds { get; init; } = 5;
 }

--- a/ELearning.Infrastructure/Options/RabbitMqOptionsValidator.cs
+++ b/ELearning.Infrastructure/Options/RabbitMqOptionsValidator.cs
@@ -47,6 +47,21 @@ public sealed class RabbitMqOptionsValidator : IValidateOptions<RabbitMqOptions>
             failures.Add("RabbitMq:ExchangeName is required when RabbitMQ is enabled.");
         }
 
+        if (string.IsNullOrWhiteSpace(options.NotificationQueueName))
+        {
+            failures.Add("RabbitMq:NotificationQueueName is required when RabbitMQ is enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.DeadLetterExchangeName))
+        {
+            failures.Add("RabbitMq:DeadLetterExchangeName is required when RabbitMQ is enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.DeadLetterQueueName))
+        {
+            failures.Add("RabbitMq:DeadLetterQueueName is required when RabbitMQ is enabled.");
+        }
+
         if (options.PublisherConfirmTimeoutSeconds <= 0)
         {
             failures.Add("RabbitMq:PublisherConfirmTimeoutSeconds must be greater than zero when RabbitMQ is enabled.");

--- a/ELearning.Infrastructure/Outbox/IntegrationEvents.cs
+++ b/ELearning.Infrastructure/Outbox/IntegrationEvents.cs
@@ -20,3 +20,15 @@ public sealed record SubmissionGradedIntegrationEvent(
     Guid EventId,
     Guid SubmissionId,
     DateTime OccurredOnUtc);
+
+public sealed record NotificationRequestedIntegrationEvent(
+    Guid EventId,
+    string NotificationType,
+    string RecipientEmail,
+    string RecipientName,
+    string Subject,
+    string Body,
+    bool IsHtml,
+    string Source,
+    Guid SourceId,
+    DateTime OccurredOnUtc);

--- a/ELearning.Infrastructure/Outbox/OutboxIntegrationEventMapper.cs
+++ b/ELearning.Infrastructure/Outbox/OutboxIntegrationEventMapper.cs
@@ -15,6 +15,8 @@ public sealed class OutboxIntegrationEventMapper : IOutboxIntegrationEventMapper
 
     public const string SubmissionGradedRoutingKey = "submission.graded.v1";
 
+    public const string NotificationRequestedRoutingKey = "notification.requested.v1";
+
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public IntegrationEventPublishMessage? Map(OutboxMessage message)
@@ -32,6 +34,11 @@ public sealed class OutboxIntegrationEventMapper : IOutboxIntegrationEventMapper
         if (IsEventType(message.Type, "SubmissionGradedEvent"))
         {
             return MapSubmissionGraded(message);
+        }
+
+        if (IsEventType(message.Type, nameof(NotificationRequestedIntegrationEvent)))
+        {
+            return MapNotificationRequested(message);
         }
 
         return null;
@@ -81,6 +88,16 @@ public sealed class OutboxIntegrationEventMapper : IOutboxIntegrationEventMapper
             message,
             nameof(SubmissionGradedIntegrationEvent),
             SubmissionGradedRoutingKey,
+            integrationEvent);
+    }
+
+    private static IntegrationEventPublishMessage MapNotificationRequested(OutboxMessage message)
+    {
+        var integrationEvent = DeserializePayload<NotificationRequestedIntegrationEvent>(message.Payload);
+        return CreatePublishMessage(
+            message,
+            nameof(NotificationRequestedIntegrationEvent),
+            NotificationRequestedRoutingKey,
             integrationEvent);
     }
 

--- a/ELearning.IntegrationTests/ConfigurationValidationTests.cs
+++ b/ELearning.IntegrationTests/ConfigurationValidationTests.cs
@@ -4,9 +4,13 @@
 
 namespace ELearning.IntegrationTests;
 
+using ELearning.Infrastructure;
+using ELearning.Infrastructure.Notifications;
 using ELearning.Infrastructure.Options;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 public sealed class ConfigurationValidationTests
 {
@@ -90,12 +94,38 @@ public sealed class ConfigurationValidationTests
                 Password = string.Empty,
                 VirtualHost = string.Empty,
                 ExchangeName = string.Empty,
+                NotificationQueueName = string.Empty,
+                DeadLetterExchangeName = string.Empty,
+                DeadLetterQueueName = string.Empty,
                 PublisherConfirmTimeoutSeconds = 0,
             });
 
         result.Failed.Should().BeTrue();
         result.Failures.Should().Contain(failure => failure.Contains("RabbitMq:HostName", StringComparison.Ordinal));
         result.Failures.Should().Contain(failure => failure.Contains("RabbitMq:ExchangeName", StringComparison.Ordinal));
+        result.Failures.Should().Contain(failure => failure.Contains("RabbitMq:NotificationQueueName", StringComparison.Ordinal));
+        result.Failures.Should().Contain(failure => failure.Contains("RabbitMq:DeadLetterExchangeName", StringComparison.Ordinal));
+        result.Failures.Should().Contain(failure => failure.Contains("RabbitMq:DeadLetterQueueName", StringComparison.Ordinal));
         result.Failures.Should().Contain(failure => failure.Contains("RabbitMq:PublisherConfirmTimeoutSeconds", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AddInfrastructure_WhenRabbitMqIsDisabled_ShouldNotRegisterNotificationConsumerHostedService()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Provider"] = "SqliteInMemory",
+                ["Database:SqliteInMemoryConnection"] = "Data Source=:memory:;Cache=Shared",
+                ["RabbitMq:Enabled"] = "false",
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddInfrastructure(configuration);
+
+        services.Should().NotContain(
+            descriptor => descriptor.ServiceType == typeof(IHostedService) &&
+                          descriptor.ImplementationType == typeof(RabbitMqNotificationConsumerHostedService));
     }
 }

--- a/ELearning.IntegrationTests/NotificationIntegrationEventHandlerTests.cs
+++ b/ELearning.IntegrationTests/NotificationIntegrationEventHandlerTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="NotificationIntegrationEventHandlerTests.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.IntegrationTests;
+
+using System.Text.Json;
+using ELearning.Application.Common.Interfaces;
+using ELearning.Infrastructure.Data;
+using ELearning.Infrastructure.Data.Models;
+using ELearning.Infrastructure.Notifications;
+using ELearning.Infrastructure.Outbox;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+public sealed class NotificationIntegrationEventHandlerTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task HandleAsync_ShouldSendEmailAndRecordProcessedMessage()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var dbContext = await CreateDbContextAsync(cancellationToken);
+        var emailService = new FakeEmailService();
+        var handler = CreateHandler(dbContext, emailService);
+        var integrationEvent = CreateNotificationRequestedEvent();
+
+        var result = await handler.HandleAsync(
+            integrationEvent.EventId,
+            nameof(NotificationRequestedIntegrationEvent),
+            JsonSerializer.Serialize(integrationEvent, JsonOptions),
+            cancellationToken);
+
+        result.Should().Be(NotificationProcessingResult.Processed);
+        emailService.SentEmails.Should().ContainSingle();
+        dbContext.ProcessedIntegrationMessages.Should().ContainSingle(
+            message => message.MessageId == integrationEvent.EventId &&
+                       message.Consumer == NotificationIntegrationEventHandler.ConsumerName);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessageWasAlreadyProcessed_ShouldNotSendEmailAgain()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var dbContext = await CreateDbContextAsync(cancellationToken);
+        var integrationEvent = CreateNotificationRequestedEvent();
+        dbContext.ProcessedIntegrationMessages.Add(new ProcessedIntegrationMessage
+        {
+            MessageId = integrationEvent.EventId,
+            Consumer = NotificationIntegrationEventHandler.ConsumerName,
+            Type = nameof(NotificationRequestedIntegrationEvent),
+            ProcessedOnUtc = DateTime.UtcNow,
+        });
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var emailService = new FakeEmailService();
+        var handler = CreateHandler(dbContext, emailService);
+
+        var result = await handler.HandleAsync(
+            integrationEvent.EventId,
+            nameof(NotificationRequestedIntegrationEvent),
+            JsonSerializer.Serialize(integrationEvent, JsonOptions),
+            cancellationToken);
+
+        result.Should().Be(NotificationProcessingResult.AlreadyProcessed);
+        emailService.SentEmails.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenEmailFails_ShouldNotRecordProcessedMessage()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var dbContext = await CreateDbContextAsync(cancellationToken);
+        var emailService = new FakeEmailService(new InvalidOperationException("Email send failed."));
+        var handler = CreateHandler(dbContext, emailService);
+        var integrationEvent = CreateNotificationRequestedEvent();
+
+        var act = async () => await handler.HandleAsync(
+            integrationEvent.EventId,
+            nameof(NotificationRequestedIntegrationEvent),
+            JsonSerializer.Serialize(integrationEvent, JsonOptions),
+            cancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Email send failed.");
+        dbContext.ProcessedIntegrationMessages.Should().BeEmpty();
+    }
+
+    private static NotificationIntegrationEventHandler CreateHandler(
+        ApplicationDbContext dbContext,
+        IEmailService emailService) =>
+        new(dbContext, emailService, NullLogger<NotificationIntegrationEventHandler>.Instance);
+
+    private static NotificationRequestedIntegrationEvent CreateNotificationRequestedEvent() =>
+        new(
+            Guid.NewGuid(),
+            "enrollment.confirmation",
+            "student@example.com",
+            "Student One",
+            "Welcome",
+            "Hello",
+            IsHtml: false,
+            "Enrollment",
+            Guid.NewGuid(),
+            DateTime.UtcNow);
+
+    private static async Task<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(cancellationToken);
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var dbContext = new ApplicationDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+        return dbContext;
+    }
+
+    private sealed class FakeEmailService(Exception? exception = null) : IEmailService
+    {
+        public List<string> SentEmails { get; } = [];
+
+        public Task SendEmailAsync(string to, string subject, string body, bool isHtml = false)
+        {
+            if (exception is not null)
+            {
+                throw exception;
+            }
+
+            this.SentEmails.Add(to);
+            return Task.CompletedTask;
+        }
+
+        public Task SendEnrollmentConfirmationAsync(string to, string studentName, string courseName) =>
+            Task.CompletedTask;
+
+        public Task SendAssignmentGradedAsync(string to, string studentName, string assignmentName, int score) =>
+            Task.CompletedTask;
+
+        public Task SendCourseApprovedAsync(string to, string instructorName, string courseName) =>
+            Task.CompletedTask;
+
+        public Task SendCourseRejectedAsync(string to, string instructorName, string courseName, string reason) =>
+            Task.CompletedTask;
+
+        public Task SendCertificateIssuedAsync(string to, string studentName, string courseName, string certificateCode) =>
+            Task.CompletedTask;
+    }
+}

--- a/ELearning.IntegrationTests/NotificationRequestServiceTests.cs
+++ b/ELearning.IntegrationTests/NotificationRequestServiceTests.cs
@@ -1,0 +1,121 @@
+// <copyright file="NotificationRequestServiceTests.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.IntegrationTests;
+
+using System.Text.Json;
+using ELearning.Application.Common.Interfaces;
+using ELearning.Infrastructure.Data;
+using ELearning.Infrastructure.Notifications;
+using ELearning.Infrastructure.Options;
+using ELearning.Infrastructure.Outbox;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+public sealed class NotificationRequestServiceTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task RequestEnrollmentConfirmationAsync_WhenRabbitMqIsDisabled_ShouldSendEmailDirectly()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var dbContext = await CreateDbContextAsync(cancellationToken);
+        var emailService = new FakeEmailService();
+        var service = new NotificationRequestService(
+            dbContext,
+            emailService,
+            Options.Create(new RabbitMqOptions { Enabled = false }));
+
+        await service.RequestEnrollmentConfirmationAsync(
+            "student@example.com",
+            "Student One",
+            "Clean Architecture",
+            Guid.NewGuid(),
+            cancellationToken);
+
+        emailService.SentEmails.Should().ContainSingle();
+        dbContext.OutboxMessages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RequestEnrollmentConfirmationAsync_WhenRabbitMqIsEnabled_ShouldWriteNotificationRequestedOutboxMessage()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var dbContext = await CreateDbContextAsync(cancellationToken);
+        var emailService = new FakeEmailService();
+        var service = new NotificationRequestService(
+            dbContext,
+            emailService,
+            Options.Create(new RabbitMqOptions { Enabled = true }));
+
+        await service.RequestEnrollmentConfirmationAsync(
+            "student@example.com",
+            "Student One",
+            "Clean Architecture",
+            Guid.NewGuid(),
+            cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        emailService.SentEmails.Should().BeEmpty();
+        var outboxMessage = dbContext.OutboxMessages.Should().ContainSingle().Subject;
+        outboxMessage.Type.Should().Be(nameof(NotificationRequestedIntegrationEvent));
+
+        var integrationEvent = JsonSerializer.Deserialize<NotificationRequestedIntegrationEvent>(
+            outboxMessage.Payload,
+            JsonOptions);
+        integrationEvent.Should().NotBeNull();
+        integrationEvent!.RecipientEmail.Should().Be("student@example.com");
+        integrationEvent.NotificationType.Should().Be("enrollment.confirmation");
+
+        var publishMessage = new OutboxIntegrationEventMapper().Map(outboxMessage);
+        publishMessage.Should().NotBeNull();
+        publishMessage!.RoutingKey.Should().Be(OutboxIntegrationEventMapper.NotificationRequestedRoutingKey);
+    }
+
+    private static async Task<ApplicationDbContext> CreateDbContextAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(cancellationToken);
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var dbContext = new ApplicationDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+        return dbContext;
+    }
+
+    private sealed class FakeEmailService : IEmailService
+    {
+        public List<string> SentEmails { get; } = [];
+
+        public Task SendEmailAsync(string to, string subject, string body, bool isHtml = false)
+        {
+            this.SentEmails.Add(to);
+            return Task.CompletedTask;
+        }
+
+        public Task SendEnrollmentConfirmationAsync(string to, string studentName, string courseName)
+        {
+            this.SentEmails.Add(to);
+            return Task.CompletedTask;
+        }
+
+        public Task SendAssignmentGradedAsync(string to, string studentName, string assignmentName, int score) =>
+            Task.CompletedTask;
+
+        public Task SendCourseApprovedAsync(string to, string instructorName, string courseName) =>
+            Task.CompletedTask;
+
+        public Task SendCourseRejectedAsync(string to, string instructorName, string courseName, string reason) =>
+            Task.CompletedTask;
+
+        public Task SendCertificateIssuedAsync(string to, string studentName, string courseName, string certificateCode) =>
+            Task.CompletedTask;
+    }
+}

--- a/ELearning.IntegrationTests/OutboxIntegrationEventMapperTests.cs
+++ b/ELearning.IntegrationTests/OutboxIntegrationEventMapperTests.cs
@@ -119,6 +119,33 @@ public sealed class OutboxIntegrationEventMapperTests
         publishMessage.Should().BeNull();
     }
 
+    [Fact]
+    public void Map_ShouldCreateNotificationRequestedIntegrationEvent()
+    {
+        var mapper = new OutboxIntegrationEventMapper();
+        var integrationEvent = new NotificationRequestedIntegrationEvent(
+            Guid.NewGuid(),
+            "enrollment.confirmation",
+            "student@example.com",
+            "Student One",
+            "Welcome",
+            "Hello",
+            IsHtml: false,
+            "Enrollment",
+            Guid.NewGuid(),
+            DateTime.UtcNow);
+        var message = CreateMessage(
+            integrationEvent.EventId,
+            nameof(NotificationRequestedIntegrationEvent),
+            integrationEvent);
+
+        var publishMessage = mapper.Map(message);
+
+        publishMessage.Should().NotBeNull();
+        publishMessage!.EventType.Should().Be(nameof(NotificationRequestedIntegrationEvent));
+        publishMessage.RoutingKey.Should().Be(OutboxIntegrationEventMapper.NotificationRequestedRoutingKey);
+    }
+
     private static OutboxMessage CreateMessage(Guid id, string type, object payload) =>
         new()
         {


### PR DESCRIPTION
## Summary
- Added NotificationRequestedIntegrationEvent with routing key notification.requested.v1.
- Added INotificationRequestService and outbox-backed notification request handling.
- Added RabbitMQ notification consumer hosted service.
- Added idempotent processing with ProcessedIntegrationMessage.
- Updated enrollment, course approval/rejection, submission grading, and certificate issuance notification paths.
- Preserved direct email fallback when RabbitMQ is disabled.

## Behavior
- RabbitMq:Enabled=false: notification requests are sent through the existing IEmailService directly.
- RabbitMq:Enabled=true: notification requests are written to the outbox and consumed asynchronously through RabbitMQ.
- Duplicate notification messages are skipped using idempotency records.
- Failed email delivery does not mark the message as processed.

## Validation
- dotnet restore ELearning.sln passed
- dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false passed with 0 warnings and 0 errors
- dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false passed: 165 tests
- dotnet list ELearning.sln package --vulnerable --include-transitive found no vulnerable packages

## Postponed
- Docker Compose
- Kubernetes
- MassTransit
- Testcontainers
- SMTP provider
- Retry queues
- Full notification center
- Separate worker project