### PR TITLE
Add Docker Compose and Kubernetes deployment readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Local Docker Compose settings. These are development-only example values.
+
+SQLSERVER_SA_PASSWORD=E_learning_Dev_123!
+
+RABBITMQ_DEFAULT_USER=elearning
+RABBITMQ_DEFAULT_PASS=elearning_dev_password
+
+JWT_ISSUER=elearning-compose
+JWT_AUDIENCE=elearning-compose
+JWT_SECRET=compose-dev-secret-at-least-32-characters
+JWT_EXPIRY_IN_DAYS=7
+JWT_REFRESH_TOKEN_EXPIRY_IN_DAYS=14
+
+OTEL_CONSOLE_EXPORTER_ENABLED=false
+OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/ELearning.API/Dockerfile
+++ b/ELearning.API/Dockerfile
@@ -1,15 +1,21 @@
-# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
-# This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
-USER $APP_UID
+# Runtime image for the API container.
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 8080
-EXPOSE 8081
 
+ENV ASPNETCORE_URLS=http://+:8080
 
-# This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+USER $APP_UID
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:8080/health/live || exit 1
+
+# Build the API project from the solution source.
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["ELearning.API/ELearning.API.csproj", "ELearning.API/"]
@@ -22,12 +28,12 @@ COPY . .
 WORKDIR "/src/ELearning.API"
 RUN dotnet build "./ELearning.API.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
-# This stage is used to publish the service project to be copied to the final stage
+# Publish the compiled API.
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./ELearning.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
+# Final runtime image.
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/README.md
+++ b/README.md
@@ -160,6 +160,34 @@ Useful endpoints:
 - Liveness probe: `/health/live`
 - Readiness probe: `/health/ready`
 
+### Running With Docker Compose
+
+The repository includes a local container stack for running the API with SQL Server and RabbitMQ:
+
+```powershell
+Copy-Item .env.example .env
+docker compose up --build -d
+```
+
+Compose services:
+
+- API: `http://localhost:8080`
+- RabbitMQ management UI: `http://localhost:15672`
+- SQL Server: `localhost,1433`
+
+Validate container health:
+
+```powershell
+Invoke-RestMethod http://localhost:8080/health/live
+Invoke-RestMethod http://localhost:8080/health/ready
+```
+
+Stop the local stack:
+
+```powershell
+docker compose down
+```
+
 Database notes:
 
 - sqlite in-memory is the default local and test experience
@@ -173,6 +201,17 @@ Observability notes:
 - console export is disabled by default and can be enabled with `Observability:ConsoleExporterEnabled`
 - OTLP export is enabled only when `Observability:OtlpEndpoint` is configured
 
+Kubernetes notes:
+
+- API deployment manifests live under `deploy/kubernetes/base`
+- the manifests use liveness, readiness, and startup probes against the health endpoints
+- SQL Server and RabbitMQ are modeled as external dependencies; use managed services or dedicated operators for real environments
+- validate manifests locally with:
+
+```powershell
+kubectl apply --dry-run=client -k deploy/kubernetes/base
+```
+
 ## Build And Test
 
 ```powershell
@@ -183,7 +222,7 @@ dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
 Current local verification:
 
 - `ELearning.Application.Tests`: `110` passing
-- `ELearning.IntegrationTests`: `40` passing
+- `ELearning.IntegrationTests`: `55` passing
 
 ## Why This Is A Strong Backend Sample
 

--- a/deploy/kubernetes/base/api-configmap.yaml
+++ b/deploy/kubernetes/base/api-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elearning-api-config
+data:
+  ASPNETCORE_ENVIRONMENT: Production
+  ASPNETCORE_URLS: http://+:8080
+  Ocelot__Enabled: "false"
+
+  Database__Provider: SqlServer
+
+  RabbitMq__Enabled: "true"
+  RabbitMq__HostName: rabbitmq
+  RabbitMq__Port: "5672"
+  RabbitMq__VirtualHost: /
+  RabbitMq__ExchangeName: elearning.integration.events
+  RabbitMq__NotificationQueueName: elearning.notifications.email
+  RabbitMq__DeadLetterExchangeName: elearning.integration.dead-letter
+  RabbitMq__DeadLetterQueueName: elearning.notifications.email.dead-letter
+  RabbitMq__PublisherConfirmTimeoutSeconds: "5"
+
+  JwtSettings__Issuer: elearning-api
+  JwtSettings__Audience: elearning-api
+  JwtSettings__ExpiryInDays: "7"
+  JwtSettings__RefreshTokenExpiryInDays: "14"
+
+  Observability__ServiceName: elearning-api
+  Observability__ConsoleExporterEnabled: "false"
+  Observability__OtlpEndpoint: ""

--- a/deploy/kubernetes/base/api-deployment.yaml
+++ b/deploy/kubernetes/base/api-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elearning-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: elearning-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: elearning-api
+        app.kubernetes.io/part-of: elearning-platform
+    spec:
+      containers:
+        - name: api
+          image: elearning-api:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: elearning-api-config
+            - secretRef:
+                name: elearning-api-secret
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/deploy/kubernetes/base/api-secret.example.yaml
+++ b/deploy/kubernetes/base/api-secret.example.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elearning-api-secret
+type: Opaque
+stringData:
+  # Example only. Replace these values with environment-specific secrets.
+  ConnectionStrings__DefaultConnection: Server=sqlserver,1433;Database=ELearning;User Id=app;Password=<replace-with-sql-password>;Encrypt=True;TrustServerCertificate=True
+  JwtSettings__Secret: <replace-with-at-least-32-character-secret>
+  RabbitMq__UserName: <replace-with-rabbitmq-username>
+  RabbitMq__Password: <replace-with-rabbitmq-password>

--- a/deploy/kubernetes/base/api-service.yaml
+++ b/deploy/kubernetes/base/api-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elearning-api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: elearning-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - api-configmap.yaml
+  - api-secret.example.yaml
+  - api-deployment.yaml
+  - api-service.yaml
+
+commonLabels:
+  app.kubernetes.io/name: elearning-api
+  app.kubernetes.io/part-of: elearning-platform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+services:
+  elearning-api:
+    image: elearning-api:local
+    build:
+      context: .
+      dockerfile: ELearning.API/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      Ocelot__Enabled: "false"
+      Database__Provider: SqlServer
+      ConnectionStrings__DefaultConnection: Server=sqlserver,1433;Database=ELearning;User Id=sa;Password=${SQLSERVER_SA_PASSWORD:-E_learning_Dev_123!};Encrypt=True;TrustServerCertificate=True
+      JwtSettings__Issuer: ${JWT_ISSUER:-elearning-compose}
+      JwtSettings__Audience: ${JWT_AUDIENCE:-elearning-compose}
+      JwtSettings__Secret: ${JWT_SECRET:-compose-dev-secret-at-least-32-characters}
+      JwtSettings__ExpiryInDays: ${JWT_EXPIRY_IN_DAYS:-7}
+      JwtSettings__RefreshTokenExpiryInDays: ${JWT_REFRESH_TOKEN_EXPIRY_IN_DAYS:-14}
+      RabbitMq__Enabled: "true"
+      RabbitMq__HostName: rabbitmq
+      RabbitMq__Port: "5672"
+      RabbitMq__UserName: ${RABBITMQ_DEFAULT_USER:-elearning}
+      RabbitMq__Password: ${RABBITMQ_DEFAULT_PASS:-elearning_dev_password}
+      RabbitMq__VirtualHost: /
+      RabbitMq__ExchangeName: elearning.integration.events
+      RabbitMq__NotificationQueueName: elearning.notifications.email
+      RabbitMq__DeadLetterExchangeName: elearning.integration.dead-letter
+      RabbitMq__DeadLetterQueueName: elearning.notifications.email.dead-letter
+      RabbitMq__PublisherConfirmTimeoutSeconds: "5"
+      Observability__ServiceName: elearning-api
+      Observability__ConsoleExporterEnabled: ${OTEL_CONSOLE_EXPORTER_ENABLED:-false}
+      Observability__OtlpEndpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health/ready || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 45s
+
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    ports:
+      - "1433:1433"
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: Developer
+      MSSQL_SA_PASSWORD: ${SQLSERVER_SA_PASSWORD:-E_learning_Dev_123!}
+    volumes:
+      - sqlserver-data:/var/opt/mssql
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$${MSSQL_SA_PASSWORD}\" -C -Q \"SELECT 1\" || /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P \"$${MSSQL_SA_PASSWORD}\" -Q \"SELECT 1\" || exit 1"
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-elearning}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-elearning_dev_password}
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+volumes:
+  sqlserver-data:
+  rabbitmq-data:


### PR DESCRIPTION
## Summary
- Updated the API Dockerfile to use .NET 10 images.
- Added a Docker Compose stack for API, SQL Server, and RabbitMQ.
- Added .env.example for local container configuration.
- Added Kubernetes Kustomize base manifests for API deployment readiness.
- Updated README with Docker Compose and Kubernetes usage notes.

## Validation
Passed:
- dotnet restore ELearning.sln
- dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false
- dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
- dotnet list ELearning.sln package --vulnerable --include-transitive
- docker compose config
- kubectl kustomize deploy/kubernetes/base

Results:
- Build passed with 0 warnings and 0 errors.
- Tests passed: 165 tests.
- Vulnerability scan found no vulnerable packages.

## Local environment limitations
The following validations could not be completed because Docker Desktop's Linux engine was not running locally:
- docker build -f ELearning.API/Dockerfile -t elearning-api:phase6 .
- docker compose up --build -d
- health endpoint checks against localhost:8080

kubectl apply --dry-run=client also could not complete because no local Kubernetes cluster was available, but the manifests render successfully with kubectl kustomize.

## Scope
No business code, API contracts, messaging behavior, or domain behavior changed.