### PR TITLE
Improve documentation and portfolio presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,141 +1,129 @@
 # E-Learning Platform API
 
-Production-inspired backend sample for an e-learning platform built as a modular monolith with Clean Architecture and DDD-inspired design.
+[![ci](https://github.com/FarazLoloei/ELearning/actions/workflows/ci.yml/badge.svg)](https://github.com/FarazLoloei/ELearning/actions/workflows/ci.yml)
 
-This repository exists as a senior-level backend portfolio project. The goal is not to showcase every possible feature, but to show deliberate architecture, explicit business workflows, and credible product behavior in a codebase that is still practical to review.
+Production-inspired backend sample for an e-learning platform built as a modular monolith with Clean Architecture, DDD-inspired workflow modeling, CQRS with MediatR, reliable messaging, and cloud-ready foundations.
+
+This repository is a senior .NET backend portfolio project. It is intentionally not a full learning-management product or a production guarantee; it is a focused sample that shows deliberate architecture, credible business workflows, and practical deployment readiness.
 
 ## Why This Project Exists
 
-Many sample backends stop at CRUD. This project is intentionally shaped around product workflows instead:
+Many sample backends stop at CRUD. This project is shaped around product workflows instead:
 
-- instructors author courses and submit them for review
-- admins govern publication through explicit moderation actions
-- students enroll in published courses
-- learners progress through lessons and assessments
-- course completion is earned through real eligibility rules
-- completed learners can review courses and receive certificates
+- instructors author courses with modules, lessons, and assignments
+- admins govern publication through review, approval, and rejection actions
+- students enroll in published courses and progress through lessons
+- assessments are submitted and graded
+- completion rules unlock review and certificate workflows
+- important outcomes are published through an outbox and RabbitMQ-backed notification flow
 
-The result is a sample that is closer to a real product backend than a database wrapper.
+## Key Features
 
-## Product Overview
+- JWT authentication with refresh-token rotation
+- role-aware workflows for students, instructors, and admins
+- course authoring, publication review, approval, rejection, and archiving
+- enrollment, lesson progression, assessment submission, grading, reviews, and certificates
+- REST API as the primary interface, with GraphQL as a secondary interface
+- consistent REST error contracts with `ProblemDetails`
+- EF Core write model, Dapper read models, SQL Server migrations, and SQLite in-memory local/test defaults
+- outbox pattern, RabbitMQ integration events, and idempotent notification processing
+- health endpoints, OpenTelemetry basics, Docker Compose, Kubernetes manifests, CI, tests, and dependency scanning
 
-The platform models three primary actors:
+## Technology Stack
 
-- `Student`
-- `Instructor`
-- `Admin`
+| Area | Technologies |
+| --- | --- |
+| Runtime | .NET 10, ASP.NET Core 10 |
+| Architecture | Clean Architecture-style layering, modular monolith, DDD-inspired aggregates |
+| Application flow | CQRS with MediatR, FluentValidation pipeline behaviors |
+| API | REST controllers, Swagger/OpenAPI, GraphQL with HotChocolate |
+| Persistence | EF Core, SQL Server migrations, SQLite in-memory, Dapper read models |
+| Messaging | Outbox pattern, RabbitMQ, idempotent notification consumer |
+| Security | JWT bearer auth, refresh tokens, role-based authorization, security audit events |
+| Observability | Health checks, OpenTelemetry tracing/metrics/logging basics |
+| Delivery readiness | Dockerfile, Docker Compose, Kubernetes Kustomize base, GitHub Actions CI |
+| Quality | Unit/domain tests, integration tests, architecture tests, vulnerability scan |
 
-Core business capabilities currently implemented:
+## Architecture At A Glance
 
-- identity and access with JWT auth and refresh-token rotation
-- course authoring and explicit course lifecycle governance
-- enrollment with lifecycle-aware eligibility
-- lesson progression and rule-driven course completion
-- assessment submission and grading
-- reviews and ratings
-- certificate issuance and verification
-- lightweight notifications for important outcomes
+```mermaid
+flowchart LR
+    Client[REST / GraphQL clients] --> API[ELearning.API]
+    API --> Application[ELearning.Application]
+    Application --> Domain[ELearning.Domain]
+    Infrastructure[ELearning.Infrastructure] --> Application
+    Infrastructure --> Domain
+    API --> Infrastructure
+    Infrastructure --> Sql[(SQL Server / SQLite)]
+    Infrastructure --> Rabbit[(RabbitMQ)]
+```
 
-## Architecture Overview
+The solution keeps business rules in the domain/application layers and keeps infrastructure concerns behind adapters. See [Architecture](docs/architecture.md) for the deeper explanation.
 
-The solution is a modular monolith with clear inward dependency direction:
+## Business Workflows
 
-- `ELearning.API`
-  REST controllers, GraphQL schema, transport concerns, composition root
-- `ELearning.Application`
-  commands, queries, handlers, DTOs, orchestration, validation, transaction pipeline
-- `ELearning.Domain`
-  aggregates, entities, value objects, invariants, explicit business behavior
-- `ELearning.Infrastructure`
-  EF Core, Dapper read models, repositories, auth adapters, email delivery, outbox dispatcher
-- `ELearning.SharedKernel`
-  small shared abstractions and base types
-- `ELearning.Application.Tests`
-  domain/application-focused tests
-- `ELearning.IntegrationTests`
-  end-to-end HTTP and authorization coverage
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> InReview: Submit for review
+    InReview --> Published: Admin approves
+    InReview --> Rejected: Admin rejects
+    Rejected --> Draft: Instructor edits
+    Published --> Archived: Archive
+```
 
-High-level dependency direction:
+Representative workflows:
 
-- `API -> Application`
-- `Infrastructure -> Application + Domain`
-- `Application -> Domain + SharedKernel`
-- `Domain -> SharedKernel`
+- instructor creates a course, adds modules/lessons/assignments, and submits it for review
+- admin approves or rejects publication
+- student enrolls in a published course
+- student progresses through lessons and assessments
+- completed students can review a course and receive a certificate
 
-## Domain And Workflow Highlights
-
-This project is intentionally centered on explicit workflows:
-
-- `Course` owns lifecycle transitions such as draft creation, review submission, approval, rejection, and archiving
-- `Enrollment` owns progression, assessment submission, review eligibility, and completion state
-- assessment definitions stay with course authoring, while assessment execution is handled through enrollment-centered workflow
-- certificates are issued only for legitimately completed enrollments and only once per enrollment
-
-Examples of non-CRUD behavior in the current model:
-
-- students can enroll only in published courses
-- only draft/rejected courses are instructor-editable
-- course completion requires lessons and required assessments
-- a course review is allowed only after authoritative completion
-- a certificate can be verified by public certificate code
-
-## Example Workflows
-
-### Course Governance
-
-1. Instructor creates a course in `Draft`
-2. Instructor submits the course for review
-3. Admin approves publication or rejects with feedback
-4. Published courses become visible in the public catalog
-
-### Learning And Completion
-
-1. Student enrolls in a published course
-2. Student starts and completes lessons explicitly
-3. Student submits required assessments
-4. Completion is earned when authoritative eligibility is satisfied
-5. Certificate issuance becomes available for that completed enrollment
-
-### Post-Completion Outcomes
-
-1. Student submits a review for the completed course
-2. Course rating is updated through the domain flow
-3. Student can retrieve or verify the issued certificate
-
-## API Surface Overview
-
-REST is the primary interface. GraphQL is available as a secondary interface that reuses the same application use cases.
-
-Representative REST capabilities:
+## API Capabilities
 
 - auth: login, register, refresh, revoke
-- courses: catalog queries, lifecycle actions, moderation actions, reviews
-- enrollments: enroll, progression actions, review submission
-- submissions: submit assessment, grade assessment
+- courses: catalog, authoring, lifecycle actions, moderation, reviews
+- enrollments: enroll, start lesson, complete lesson, submit review
+- submissions: create and grade assessment submissions
 - certificates: issue, retrieve by enrollment, verify by public code
 
-Transport design notes:
+Useful endpoints:
 
-- REST responses use a consistent response envelope
-- GraphQL is intentionally secondary and does not duplicate business logic
-- controllers and GraphQL mutations stay thin and delegate to application handlers
+- Swagger UI: `/`
+- REST: `/api/v1/*` and compatibility routes under `/api/*`
+- GraphQL: `/graphql`
+- Liveness probe: `/health/live`
+- Readiness probe: `/health/ready`
 
-## Key Technical Decisions And Tradeoffs
+## Messaging, Outbox, And Notifications
 
-- The project uses a modular monolith instead of microservices to keep the sample cohesive and reviewable.
-- Domain modeling is DDD-inspired, not dogmatic. Aggregates are used where they add clarity and invariant protection.
-- The application layer orchestrates use cases explicitly instead of relying on broad services or fat controllers.
-- Infrastructure contains adapters and persistence details, not business workflow orchestration.
-- Notifications are intentionally lightweight. The project uses the existing email seam for valuable outcomes instead of building a full notification center.
-- Certificates are simple, verifiable records. This sample does not add document rendering or PDF generation because that would add more infrastructure spectacle than product signal.
+Domain events are persisted to an outbox during the same database save. A hosted publisher maps supported outbox messages to integration events and publishes them to RabbitMQ when messaging is enabled. Notification requests use a dedicated `notification.requested.v1` integration event and are handled idempotently by a RabbitMQ consumer.
 
-## Running The Project
+Implemented routing keys include:
+
+- `course.published.v1`
+- `student.enrolled.v1`
+- `submission.graded.v1`
+- `notification.requested.v1`
+
+See [Messaging](docs/messaging.md) and [ADR 0002](docs/adr/0002-outbox-rabbitmq-notifications.md).
+
+## Observability And Health
+
+- `/health/live` checks the process is alive
+- `/health/ready` checks database connectivity
+- OpenTelemetry tracing, metrics, and logging are configured at startup
+- console export is disabled by default
+- OTLP export is enabled only when `Observability:OtlpEndpoint` is configured
+
+## Run Locally
 
 Prerequisites:
 
 - .NET 10 SDK
 
-Configure local secrets for JWT settings:
+Configure local JWT secrets:
 
 ```powershell
 dotnet user-secrets set "JwtSettings:Issuer" "elearning-local" --project ELearning.API/ELearning.API.csproj
@@ -152,71 +140,62 @@ Run the API:
 dotnet run --project ELearning.API/ELearning.API.csproj
 ```
 
-Useful endpoints:
+## Docker Compose Quick Start
 
-- Swagger UI: `/`
-- REST: `/api/v1/*` and compatibility routes under `/api/*`
-- GraphQL: `/graphql`
-- Liveness probe: `/health/live`
-- Readiness probe: `/health/ready`
-
-### Running With Docker Compose
-
-The repository includes a local container stack for running the API with SQL Server and RabbitMQ:
+The local container stack runs the API with SQL Server and RabbitMQ:
 
 ```powershell
 Copy-Item .env.example .env
 docker compose up --build -d
 ```
 
-Compose services:
+Services:
 
 - API: `http://localhost:8080`
 - RabbitMQ management UI: `http://localhost:15672`
 - SQL Server: `localhost,1433`
 
-Validate container health:
+Validate health:
 
 ```powershell
 Invoke-RestMethod http://localhost:8080/health/live
 Invoke-RestMethod http://localhost:8080/health/ready
 ```
 
-Stop the local stack:
+Stop the stack:
 
 ```powershell
 docker compose down
 ```
 
-Database notes:
+## Kubernetes Readiness
 
-- sqlite in-memory is the default local and test experience
-- SQL Server is the production-capable relational provider and uses EF Core migrations
-- Dapper read models use provider-aware SQL fragments for paging and simple string concatenation
+Kustomize base manifests live under `deploy/kubernetes/base` and include:
 
-Observability notes:
+- API deployment
+- ClusterIP service
+- ConfigMap
+- example Secret
+- liveness, readiness, and startup probes
+- resource requests and limits
 
-- OpenTelemetry tracing, metrics, and logging are configured at startup
-- ASP.NET Core and HTTP client instrumentation are enabled
-- console export is disabled by default and can be enabled with `Observability:ConsoleExporterEnabled`
-- OTLP export is enabled only when `Observability:OtlpEndpoint` is configured
+The Kubernetes files model SQL Server and RabbitMQ as external dependencies. For a real environment, use managed services or dedicated operators instead of treating these sample manifests as full production infrastructure.
 
-Kubernetes notes:
-
-- API deployment manifests live under `deploy/kubernetes/base`
-- the manifests use liveness, readiness, and startup probes against the health endpoints
-- SQL Server and RabbitMQ are modeled as external dependencies; use managed services or dedicated operators for real environments
-- validate manifests locally with:
+Render manifests:
 
 ```powershell
-kubectl apply --dry-run=client -k deploy/kubernetes/base
+kubectl kustomize deploy/kubernetes/base
 ```
 
-## Build And Test
+## Validate The Project
 
 ```powershell
+dotnet restore ELearning.sln
 dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false
 dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
+dotnet list ELearning.sln package --vulnerable --include-transitive
+docker compose config
+kubectl kustomize deploy/kubernetes/base
 ```
 
 Current local verification:
@@ -224,27 +203,33 @@ Current local verification:
 - `ELearning.Application.Tests`: `110` passing
 - `ELearning.IntegrationTests`: `55` passing
 
+## Documentation
+
+- [Architecture](docs/architecture.md)
+- [Messaging](docs/messaging.md)
+- [Deployment](docs/deployment.md)
+- [Testing](docs/testing.md)
+- [ADR 0001: Modular Monolith](docs/adr/0001-modular-monolith.md)
+- [ADR 0002: Outbox, RabbitMQ, And Notifications](docs/adr/0002-outbox-rabbitmq-notifications.md)
+
+## Security Notes
+
+- JWT secrets are configured through user secrets, environment variables, or Kubernetes Secrets.
+- Development `.env.example` values are examples only and should not be reused for real environments.
+- CI runs restore, build, tests with coverage, and transitive dependency vulnerability scanning.
+- The sample does not include a real SMTP provider, payment provider, file storage provider, or production identity provider.
+
+## Known Limitations
+
+- Email delivery is represented by an application seam and logging implementation, not a real SMTP or third-party provider.
+- Kubernetes manifests are API readiness artifacts, not a full production platform.
+- SQL Server and RabbitMQ production hosting are intentionally left to managed services or dedicated operators.
+- GraphQL is secondary and does not attempt to expose every REST workflow.
+- The project focuses on backend architecture and workflows, not a frontend UI.
+
 ## Why This Is A Strong Backend Sample
 
-This project is strongest where reviewers usually look for senior-level judgment:
-
-- explicit workflow modeling instead of generic status mutation
-- deliberate layer boundaries with architecture tests
-- domain rules placed in aggregates and application use cases instead of controllers
-- pragmatic read/write separation without unnecessary distributed complexity
-- credible auth, moderation, progression, assessment, review, certificate, and notification flows
-
-It is intentionally not a “perfect enterprise platform.” It is a realistic sample that balances architecture quality with repo readability.
-
-## Future Improvements
-
-Good next steps if the project were extended further:
-
-- richer authoring flows for modules, lessons, and assessments
-- review moderation and review editing policies
-- certificate rendering/export if the product needs it
-- stronger notification persistence/history beyond email delivery
-- deployment guidance and production environment configuration examples
+This project demonstrates senior-level backend judgment through explicit workflow modeling, clear layer boundaries, pragmatic CQRS, provider-aware persistence, reliable messaging foundations, observable health endpoints, deployment-ready artifacts, and meaningful automated tests without turning the sample into an over-engineered platform.
 
 ## License
 

--- a/docs/adr/0001-modular-monolith.md
+++ b/docs/adr/0001-modular-monolith.md
@@ -1,0 +1,48 @@
+# ADR 0001: Modular Monolith
+
+## Status
+
+Accepted
+
+## Context
+
+The project is a public backend portfolio sample for an e-learning domain. It needs to demonstrate senior engineering judgment without becoming difficult to review.
+
+The domain has multiple capabilities:
+
+- auth
+- course authoring
+- enrollment
+- progression
+- assessments
+- certificates
+- notifications
+
+These capabilities are related enough that splitting them into services would add distributed-system complexity before there is a real scaling or team-boundary need.
+
+## Decision
+
+Use a modular monolith with Clean Architecture-style dependency direction.
+
+The codebase keeps separate projects for API, Application, Domain, Infrastructure, SharedKernel, and tests. Modules are separated by folders and use cases rather than process boundaries.
+
+## Consequences
+
+Benefits:
+
+- easier to run and review
+- transactions remain straightforward
+- domain workflows stay cohesive
+- architecture still demonstrates clear boundaries
+- later extraction remains possible if a real need appears
+
+Tradeoffs:
+
+- modules are not independently deployable
+- scaling is at the application level
+- boundaries rely on code structure, tests, and discipline rather than network isolation
+
+## Alternatives Considered
+
+- Microservices: rejected because they would add operational overhead and messaging complexity not justified by the sample.
+- Simple CRUD layering: rejected because it would not demonstrate the product workflows and domain behavior the project is meant to show.

--- a/docs/adr/0002-outbox-rabbitmq-notifications.md
+++ b/docs/adr/0002-outbox-rabbitmq-notifications.md
@@ -1,0 +1,46 @@
+# ADR 0002: Outbox, RabbitMQ, And Notifications
+
+## Status
+
+Accepted
+
+## Context
+
+The application sends lightweight notifications for important outcomes such as enrollment, course approval, grading, and certificate issuance.
+
+Direct email calls are simple, but they couple user-facing workflows to notification delivery. A public backend sample also benefits from demonstrating reliable asynchronous integration without becoming a microservice system.
+
+## Decision
+
+Use the outbox pattern and RabbitMQ for integration-event publishing, while keeping the application a modular monolith.
+
+Notification delivery uses:
+
+- outbox messages persisted with application changes
+- RabbitMQ topic exchange for integration events
+- `notification.requested.v1` event for email-ready notification payloads
+- idempotent consumer tracking through `ProcessedIntegrationMessages`
+- existing `IEmailService` seam for delivery behavior
+
+RabbitMQ is config-gated and disabled by default so local tests do not require a broker.
+
+## Consequences
+
+Benefits:
+
+- application workflows do not depend on immediate broker availability when writing state
+- notification delivery can be asynchronous when RabbitMQ is enabled
+- duplicate consumer messages are handled idempotently
+- the sample demonstrates practical reliability patterns
+
+Tradeoffs:
+
+- there is more infrastructure code than direct email calls
+- notification history is not a full product feature
+- no delayed retry queue or operational replay UI exists yet
+
+## Alternatives Considered
+
+- Direct email only: simpler, but less useful as a reliability sample.
+- MassTransit: powerful, but heavier than needed for this focused portfolio project.
+- Separate worker service: postponed until independent deployment or scaling is actually needed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,92 @@
+# Architecture
+
+This application is a production-inspired modular monolith. It uses Clean Architecture-style dependency direction, DDD-inspired tactical modeling where it adds clarity, and CQRS with MediatR for application use cases.
+
+## Layered Structure
+
+```mermaid
+flowchart TB
+    API[ELearning.API<br/>REST, GraphQL, middleware, startup]
+    Application[ELearning.Application<br/>commands, queries, validation, orchestration]
+    Domain[ELearning.Domain<br/>aggregates, entities, value objects, invariants]
+    Infrastructure[ELearning.Infrastructure<br/>EF Core, Dapper, auth, messaging, email adapters]
+    Shared[ELearning.SharedKernel<br/>base abstractions]
+    Tests[Tests<br/>application, domain, integration, architecture]
+
+    API --> Application
+    API --> Infrastructure
+    Infrastructure --> Application
+    Infrastructure --> Domain
+    Application --> Domain
+    Application --> Shared
+    Domain --> Shared
+    Tests --> API
+    Tests --> Application
+    Tests --> Domain
+    Tests --> Infrastructure
+```
+
+Dependency direction points inward toward the domain. Infrastructure implements adapters and persistence details; it does not own business workflow decisions.
+
+## Project Responsibilities
+
+| Project | Responsibility |
+| --- | --- |
+| `ELearning.API` | HTTP/GraphQL transport, authentication setup, middleware, Swagger, health checks, composition root |
+| `ELearning.Application` | Use-case orchestration through commands and queries, validation, DTOs, transaction pipeline |
+| `ELearning.Domain` | Business invariants, aggregate behavior, value objects, domain events |
+| `ELearning.Infrastructure` | EF Core repositories, Dapper read models, SQL dialects, JWT adapters, email seam, outbox, RabbitMQ |
+| `ELearning.SharedKernel` | Small shared abstractions such as base entity/domain event contracts |
+| `ELearning.Application.Tests` | Domain and application behavior tests |
+| `ELearning.IntegrationTests` | HTTP, infrastructure, health, authorization, outbox, and configuration behavior |
+
+## Business Modules
+
+- Auth and user registration
+- Course authoring and lifecycle governance
+- Modules, lessons, and assignments
+- Enrollment and lesson progression
+- Submissions and grading
+- Reviews and ratings
+- Certificate issuance and verification
+- Notifications through outbox/RabbitMQ
+
+## Course Authoring Workflow
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft: Create course
+    Draft --> Draft: Add modules, lessons, assignments
+    Draft --> InReview: Submit for review
+    InReview --> Published: Admin approves
+    InReview --> Rejected: Admin rejects
+    Rejected --> Draft: Instructor edits
+    Published --> Archived: Archive
+```
+
+Course lifecycle rules are enforced by domain behavior rather than controllers. Application handlers orchestrate repository access, authorization checks, and transaction boundaries.
+
+## CQRS And Validation
+
+Commands and queries are represented with MediatR request handlers. FluentValidation validates request models before handlers execute. Cross-cutting behaviors include validation, logging, and transaction handling.
+
+This is pragmatic CQRS, not a separate service or separate database-per-side architecture.
+
+## Persistence
+
+- EF Core is used for the write model and aggregate persistence.
+- SQL Server is the production-capable relational provider and uses migrations.
+- SQLite in-memory is the default lightweight local/test provider.
+- Dapper read repositories provide focused read models.
+- Provider-aware SQL helpers keep Dapper reads honest across supported providers.
+
+## API Surface
+
+REST is the primary API. GraphQL is available as a secondary interface and reuses the same application use cases. The project avoids duplicating business logic in transport layers.
+
+## Tradeoffs
+
+- Modular monolith over microservices keeps the sample reviewable and avoids distributed complexity that the product does not yet need.
+- DDD patterns are used where they protect meaningful rules, not for every object.
+- Messaging is included for reliability and asynchronous notification delivery, not as a microservice boundary.
+- Kubernetes manifests show deployment readiness for the API, not a full production platform.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,116 @@
+# Deployment
+
+The project includes deployment-readiness artifacts for local containers and basic Kubernetes API manifests. These files are meant to make the sample runnable and reviewable outside the IDE.
+
+They are not a complete production platform.
+
+## Docker Compose
+
+Compose starts:
+
+- `elearning-api`
+- `sqlserver`
+- `rabbitmq`
+
+```mermaid
+flowchart LR
+    Browser[Browser / API client] --> API[elearning-api<br/>ASP.NET Core]
+    API --> SQL[(sqlserver<br/>SQL Server)]
+    API --> MQ[(rabbitmq<br/>AMQP)]
+    MQ --> UI[RabbitMQ management UI]
+```
+
+Start the stack:
+
+```powershell
+Copy-Item .env.example .env
+docker compose up --build -d
+```
+
+Useful URLs:
+
+- API: `http://localhost:8080`
+- Swagger UI: `http://localhost:8080/`
+- RabbitMQ management UI: `http://localhost:15672`
+- SQL Server: `localhost,1433`
+
+Health checks:
+
+```powershell
+Invoke-RestMethod http://localhost:8080/health/live
+Invoke-RestMethod http://localhost:8080/health/ready
+```
+
+Stop the stack:
+
+```powershell
+docker compose down
+```
+
+Remove local volumes if you want a clean database and broker state:
+
+```powershell
+docker compose down -v
+```
+
+## Container Configuration
+
+Key environment variables:
+
+- `ASPNETCORE_URLS=http://+:8080`
+- `Database__Provider=SqlServer`
+- `ConnectionStrings__DefaultConnection`
+- `JwtSettings__Issuer`
+- `JwtSettings__Audience`
+- `JwtSettings__Secret`
+- `RabbitMq__Enabled=true`
+- `RabbitMq__HostName=rabbitmq`
+- `RabbitMq__UserName`
+- `RabbitMq__Password`
+- `Observability__ConsoleExporterEnabled`
+- `Observability__OtlpEndpoint`
+
+The API runs EF Core migrations on startup when the provider is SQL Server.
+
+## Kubernetes Base
+
+Kustomize manifests live under `deploy/kubernetes/base`.
+
+Included:
+
+- API deployment
+- ClusterIP service
+- ConfigMap
+- example Secret
+- liveness, readiness, and startup probes
+- resource requests and limits
+
+```mermaid
+flowchart LR
+    Client[Ingress or internal client] --> Svc[elearning-api Service]
+    Svc --> Pod[API Pod]
+    Pod --> Secret[Kubernetes Secret]
+    Pod --> Config[ConfigMap]
+    Pod --> SQL[(External SQL Server)]
+    Pod --> MQ[(External RabbitMQ)]
+```
+
+Render manifests:
+
+```powershell
+kubectl kustomize deploy/kubernetes/base
+```
+
+Client dry-run, when a local cluster context is available:
+
+```powershell
+kubectl apply --dry-run=client -k deploy/kubernetes/base
+```
+
+## Production Caveats
+
+- The Kubernetes base does not deploy SQL Server or RabbitMQ.
+- Use managed services or dedicated operators for real database/broker hosting.
+- Replace `api-secret.example.yaml` values before applying anything to a real cluster.
+- Add Ingress, TLS, network policies, autoscaling, and centralized observability according to the target environment.
+- This repo intentionally avoids cloud-provider-specific deployment.

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -1,0 +1,112 @@
+# Messaging
+
+Messaging is implemented as a reliability feature inside the modular monolith. Domain events are captured in an outbox, mapped to integration events, and published to RabbitMQ when messaging is enabled.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Handler as Application Handler
+    participant Db as ApplicationDbContext
+    participant Outbox as OutboxMessages
+    participant Publisher as Outbox Publisher
+    participant Rabbit as RabbitMQ
+    participant Consumer as Notification Consumer
+    participant Email as IEmailService
+    participant Inbox as ProcessedIntegrationMessages
+
+    Handler->>Db: Save aggregate changes
+    Db->>Outbox: Store domain/integration event payloads
+    Publisher->>Outbox: Load unprocessed messages
+    Publisher->>Rabbit: Publish integration event
+    Publisher->>Outbox: Mark processed after publish
+    Rabbit->>Consumer: Deliver notification.requested.v1
+    Consumer->>Inbox: Check duplicate message id
+    Consumer->>Email: Send email through existing seam
+    Consumer->>Inbox: Record processed message
+    Consumer->>Rabbit: Acknowledge
+```
+
+## Domain Events vs Integration Events
+
+Domain events describe things that happened inside the domain model. Integration events are external contracts published through RabbitMQ.
+
+The outbox mapper currently supports:
+
+| Source | Routing key | Integration event |
+| --- | --- | --- |
+| Course publication | `course.published.v1` | `CoursePublishedIntegrationEvent` |
+| Enrollment creation | `student.enrolled.v1` | `StudentEnrolledIntegrationEvent` |
+| Submission grading | `submission.graded.v1` | `SubmissionGradedIntegrationEvent` |
+| Notification request | `notification.requested.v1` | `NotificationRequestedIntegrationEvent` |
+
+Unsupported internal events are intentionally skipped by the publisher and marked processed so they do not block the outbox.
+
+## Outbox Publisher
+
+The outbox publisher is a hosted service registered only when `RabbitMq:Enabled=true`.
+
+Behavior:
+
+- reads unprocessed outbox messages in order
+- maps supported rows to integration events
+- publishes JSON messages to a durable RabbitMQ topic exchange
+- sets message id from the outbox id
+- uses persistent delivery mode and publisher confirmations
+- marks a row processed only after successful publish
+- stores error and increments retry count on failure
+
+When RabbitMQ is disabled, the application still runs and does not require a broker.
+
+## Notification Requests
+
+Application workflows use `INotificationRequestService` instead of directly depending on RabbitMQ.
+
+When RabbitMQ is disabled:
+
+- notification requests call the existing `IEmailService` directly
+- local development and tests do not need a broker
+
+When RabbitMQ is enabled:
+
+- notification requests write `NotificationRequestedIntegrationEvent` to the outbox
+- the outbox publisher sends it to RabbitMQ
+- the notification consumer handles it asynchronously
+
+## Idempotency
+
+The notification consumer records processed messages in `ProcessedIntegrationMessages`.
+
+The key is:
+
+- `MessageId`
+- `Consumer`
+
+Before sending email, the consumer checks whether the message was already processed. Duplicate messages are acknowledged without sending again. Failed email handling does not create a processed record.
+
+## RabbitMQ Configuration
+
+Important settings:
+
+- `RabbitMq__Enabled`
+- `RabbitMq__HostName`
+- `RabbitMq__UserName`
+- `RabbitMq__Password`
+- `RabbitMq__ExchangeName`
+- `RabbitMq__NotificationQueueName`
+- `RabbitMq__DeadLetterExchangeName`
+- `RabbitMq__DeadLetterQueueName`
+
+The Docker Compose stack enables RabbitMQ to exercise the outbox publisher and notification consumer locally.
+
+## Intentionally Postponed
+
+- MassTransit
+- separate worker project
+- real SMTP/provider integration
+- delayed retry queues
+- operational replay UI
+- RabbitMQ cluster/operator setup
+- notification history UI
+
+Those would make sense only when product and operational needs justify them.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,70 @@
+# Testing
+
+The test suite is designed to demonstrate behavior, architecture boundaries, and infrastructure integration without requiring external services for normal test runs.
+
+## Test Projects
+
+| Project | Focus |
+| --- | --- |
+| `ELearning.Application.Tests` | domain behavior, application services, DTO validation, architecture rules |
+| `ELearning.IntegrationTests` | HTTP workflows, authentication/authorization, health checks, configuration, persistence, outbox, notification idempotency |
+
+Current local verification:
+
+- `ELearning.Application.Tests`: `110` passing
+- `ELearning.IntegrationTests`: `55` passing
+
+## Coverage Themes
+
+- course lifecycle and authoring behavior
+- enrollment progression and completion rules
+- assessment workflow
+- certificate issuance
+- authorization and role behavior
+- REST error contracts
+- health endpoints
+- configuration validation
+- outbox publishing behavior
+- notification request and idempotency behavior
+- architecture dependency direction
+
+## CI Quality Gates
+
+GitHub Actions runs on pull requests and pushes to `master`.
+
+Pipeline:
+
+- restore
+- build
+- nullable warning gate
+- tests with coverage collection
+- transitive dependency vulnerability scan
+- upload coverage and scan artifacts
+
+## Local Validation
+
+```powershell
+dotnet restore ELearning.sln
+dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false
+dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
+dotnet list ELearning.sln package --vulnerable --include-transitive
+```
+
+Deployment artifact checks:
+
+```powershell
+docker compose config
+kubectl kustomize deploy/kubernetes/base
+```
+
+## External Dependencies In Tests
+
+Normal tests do not require:
+
+- live SQL Server
+- live RabbitMQ
+- Docker
+- Kubernetes
+- SMTP
+
+SQLite in-memory and fakes are used where practical. Docker Compose exists for local runtime validation, not as a required test dependency.


### PR DESCRIPTION
## Summary
- Updated README.md into a concise GitHub portfolio landing page.
- Added CI badge, technology stack table, quick-start sections, Mermaid diagrams, and honest limitations.
- Added focused documentation for architecture, messaging, deployment, and testing.
- Added ADRs for the modular monolith decision and the outbox/RabbitMQ notification design.

## New documentation
- docs/architecture.md
- docs/messaging.md
- docs/deployment.md
- docs/testing.md
- docs/adr/0001-modular-monolith.md
- docs/adr/0002-outbox-rabbitmq-notifications.md

## Validation
- dotnet restore ELearning.sln passed
- dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false passed with 0 warnings and 0 errors
- dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false passed: 165 tests
- docker compose config passed
- kubectl kustomize deploy/kubernetes/base passed
- README/docs link checks passed
- Mermaid fences are present and correctly marked
- CI badge points to FarazLoloei/ELearning

## Scope
Documentation-only change. No application code, business logic, API contracts, Docker/Kubernetes manifests, CI/CD, or tests were changed.