### PR TITLE
Polish REST-first API request contracts

### DIFF
--- a/ELearning.API/Controllers/CoursesController.cs
+++ b/ELearning.API/Controllers/CoursesController.cs
@@ -7,6 +7,7 @@ namespace ELearning.API.Controllers;
 using Asp.Versioning;
 using ELearning.API.Contracts;
 using ELearning.API.Facades;
+using ELearning.API.Mapping;
 using ELearning.API.Models;
 using ELearning.Application.Courses.Commands;
 using ELearning.Application.Courses.Dtos;
@@ -110,9 +111,10 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ApiResponse<object?>>> CreateCourse(
-        CreateCourseCommand command,
+        CreateCourseRequest request,
         CancellationToken cancellationToken)
     {
+        var command = request.ToCommand();
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
@@ -129,14 +131,15 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ApiResponse<object?>>> UpdateCourse(
         Guid id,
-        UpdateCourseCommand command,
+        UpdateCourseRequest request,
         CancellationToken cancellationToken)
     {
-        if (id != command.CourseId)
+        if (id != request.CourseId)
         {
             return this.RouteIdMismatchResponse<object?>("CourseId");
         }
 
+        var command = request.ToCommand();
         var result = await apiFacade.SendAsync(command, cancellationToken);
         return this.FromResult(result);
     }
@@ -265,14 +268,15 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ApiResponse<object?>>> RejectPublication(
         Guid id,
-        RejectCoursePublicationCommand command,
+        RejectCoursePublicationRequest request,
         CancellationToken cancellationToken)
     {
-        if (id != command.CourseId)
+        if (id != request.CourseId)
         {
             return this.RouteIdMismatchResponse<object?>("CourseId");
         }
 
+        var command = request.ToCommand();
         var result = await apiFacade.SendAsync(command, cancellationToken);
         return this.FromResult(result);
     }

--- a/ELearning.API/Controllers/EnrollmentsController.cs
+++ b/ELearning.API/Controllers/EnrollmentsController.cs
@@ -7,6 +7,7 @@ namespace ELearning.API.Controllers;
 using Asp.Versioning;
 using ELearning.API.Contracts;
 using ELearning.API.Facades;
+using ELearning.API.Mapping;
 using ELearning.API.Models;
 using ELearning.Application.Enrollments.Commands;
 using ELearning.Application.Enrollments.Dtos;
@@ -35,9 +36,10 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ApiResponse<object?>>> CreateEnrollment(
-        CreateEnrollmentCommand command,
+        CreateEnrollmentRequest request,
         CancellationToken cancellationToken)
     {
+        var command = request.ToCommand();
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
@@ -82,14 +84,15 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ApiResponse<object?>>> UpdateEnrollmentStatus(
         Guid id,
-        UpdateEnrollmentStatusCommand command,
+        UpdateEnrollmentStatusRequest request,
         CancellationToken cancellationToken)
     {
-        if (id != command.EnrollmentId)
+        if (id != request.EnrollmentId)
         {
             return this.RouteIdMismatchResponse<object?>("EnrollmentId");
         }
 
+        var command = request.ToCommand();
         var result = await apiFacade.SendAsync(command, cancellationToken);
         return this.FromResult(result);
     }

--- a/ELearning.API/Controllers/SubmissionsController.cs
+++ b/ELearning.API/Controllers/SubmissionsController.cs
@@ -7,7 +7,8 @@ namespace ELearning.API.Controllers;
 using Asp.Versioning;
 using ELearning.API.Contracts;
 using ELearning.API.Facades;
-using ELearning.Application.Submissions.Commands;
+using ELearning.API.Mapping;
+using ELearning.API.Models;
 using ELearning.Application.Submissions.Dtos;
 using ELearning.Application.Submissions.Queries;
 using Microsoft.AspNetCore.Authorization;
@@ -34,9 +35,10 @@ public class SubmissionsController(IApiFacade apiFacade) : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ApiResponse<object?>>> CreateSubmission(
-        CreateSubmissionCommand command,
+        CreateSubmissionRequest request,
         CancellationToken cancellationToken)
     {
+        var command = request.ToCommand();
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
@@ -53,14 +55,15 @@ public class SubmissionsController(IApiFacade apiFacade) : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ApiResponse<object?>>> GradeSubmission(
         Guid id,
-        GradeSubmissionCommand command,
+        GradeSubmissionRequest request,
         CancellationToken cancellationToken)
     {
-        if (id != command.SubmissionId)
+        if (id != request.SubmissionId)
         {
             return this.RouteIdMismatchResponse<object?>("SubmissionId");
         }
 
+        var command = request.ToCommand();
         var result = await apiFacade.SendAsync(command, cancellationToken);
         return this.FromResult(result);
     }

--- a/ELearning.API/ELearning.API.http
+++ b/ELearning.API/ELearning.API.http
@@ -1,6 +1,138 @@
-@ELearning.API_HostAddress = http://localhost:5080
+@host = http://localhost:5080
+@password = P@ssword123!
+@instructorEmail = instructor{{$guid}}@example.com
+@studentEmail = student{{$guid}}@example.com
 
-GET {{ELearning.API_HostAddress}}/weatherforecast/
+# Replace these placeholders with IDs returned by the API or seeded data.
+@courseId = 00000000-0000-0000-0000-000000000000
+@moduleId = 00000000-0000-0000-0000-000000000000
+@lessonId = 00000000-0000-0000-0000-000000000000
+@assignmentId = 00000000-0000-0000-0000-000000000000
+@publishedCourseId = 00000000-0000-0000-0000-000000000000
+
+### Health - live
+GET {{host}}/health/live
 Accept: application/json
 
-###
+### Health - ready
+GET {{host}}/health/ready
+Accept: application/json
+
+### Register instructor
+# @name registerInstructor
+POST {{host}}/api/auth/register/instructor
+Content-Type: application/json
+
+{
+  "firstName": "Ada",
+  "lastName": "Instructor",
+  "email": "{{instructorEmail}}",
+  "password": "{{password}}",
+  "bio": "Backend engineering instructor.",
+  "expertise": "Clean Architecture, .NET, cloud-ready APIs"
+}
+
+### Login instructor
+# @name loginInstructor
+POST {{host}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "{{instructorEmail}}",
+  "password": "{{password}}"
+}
+
+### Register student
+# @name registerStudent
+POST {{host}}/api/auth/register/student
+Content-Type: application/json
+
+{
+  "firstName": "Sam",
+  "lastName": "Student",
+  "email": "{{studentEmail}}",
+  "password": "{{password}}"
+}
+
+### Login student
+# @name loginStudent
+POST {{host}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "{{studentEmail}}",
+  "password": "{{password}}"
+}
+
+### Create course
+POST {{host}}/api/courses
+Authorization: Bearer {{loginInstructor.response.body.$.data.token}}
+Content-Type: application/json
+
+{
+  "title": "REST-First API Design with .NET",
+  "description": "A portfolio sample course for pragmatic backend API design.",
+  "categoryId": 1,
+  "levelId": 2,
+  "price": 0,
+  "durationHours": 2,
+  "durationMinutes": 30
+}
+
+### Add module
+POST {{host}}/api/courses/{{courseId}}/modules
+Authorization: Bearer {{loginInstructor.response.body.$.data.token}}
+Content-Type: application/json
+
+{
+  "title": "Module 1",
+  "description": "REST API contract fundamentals.",
+  "order": 1
+}
+
+### Add lesson
+POST {{host}}/api/courses/{{courseId}}/modules/{{moduleId}}/lessons
+Authorization: Bearer {{loginInstructor.response.body.$.data.token}}
+Content-Type: application/json
+
+{
+  "title": "Public API contracts",
+  "content": "Keep transport contracts separate from application commands.",
+  "typeId": 2,
+  "order": 1,
+  "durationHours": 0,
+  "durationMinutes": 20
+}
+
+### Add assignment
+POST {{host}}/api/courses/{{courseId}}/modules/{{moduleId}}/assignments
+Authorization: Bearer {{loginInstructor.response.body.$.data.token}}
+Content-Type: application/json
+
+{
+  "title": "Contract review",
+  "description": "Review a controller and identify transport/application coupling.",
+  "typeId": 1,
+  "maxPoints": 10
+}
+
+### Submit course for review
+POST {{host}}/api/courses/{{courseId}}/submit-for-review
+Authorization: Bearer {{loginInstructor.response.body.$.data.token}}
+
+### Enroll student in published course
+POST {{host}}/api/enrollments
+Authorization: Bearer {{loginStudent.response.body.$.data.token}}
+Content-Type: application/json
+
+{
+  "courseId": "{{publishedCourseId}}"
+}
+
+### GraphQL secondary API example - public course catalog query
+POST {{host}}/graphql
+Content-Type: application/json
+
+{
+  "query": "query { courses(first: 5) { nodes { id title instructorName category level } } }"
+}

--- a/ELearning.API/Mapping/CourseRequestMapper.cs
+++ b/ELearning.API/Mapping/CourseRequestMapper.cs
@@ -1,0 +1,36 @@
+// <copyright file="CourseRequestMapper.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Mapping;
+
+using ELearning.API.Models;
+using ELearning.Application.Courses.Commands;
+
+internal static class CourseRequestMapper
+{
+    public static CreateCourseCommand ToCommand(this CreateCourseRequest request) =>
+        new(
+            request.Title,
+            request.Description,
+            request.CategoryId,
+            request.LevelId,
+            request.Price,
+            request.DurationHours,
+            request.DurationMinutes);
+
+    public static UpdateCourseCommand ToCommand(this UpdateCourseRequest request) =>
+        new(
+            request.CourseId,
+            request.Title,
+            request.Description,
+            request.CategoryId,
+            request.LevelId,
+            request.Price,
+            request.DurationHours,
+            request.DurationMinutes,
+            request.IsFeatured);
+
+    public static RejectCoursePublicationCommand ToCommand(this RejectCoursePublicationRequest request) =>
+        new(request.CourseId, request.Reason);
+}

--- a/ELearning.API/Mapping/EnrollmentRequestMapper.cs
+++ b/ELearning.API/Mapping/EnrollmentRequestMapper.cs
@@ -1,0 +1,24 @@
+// <copyright file="EnrollmentRequestMapper.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Mapping;
+
+using ELearning.API.Models;
+using ELearning.Application.Enrollments.Commands;
+
+internal static class EnrollmentRequestMapper
+{
+    public static CreateEnrollmentCommand ToCommand(this CreateEnrollmentRequest request) =>
+        new()
+        {
+            CourseId = request.CourseId,
+        };
+
+    public static UpdateEnrollmentStatusCommand ToCommand(this UpdateEnrollmentStatusRequest request) =>
+        new()
+        {
+            EnrollmentId = request.EnrollmentId,
+            Status = request.Status,
+        };
+}

--- a/ELearning.API/Mapping/SubmissionRequestMapper.cs
+++ b/ELearning.API/Mapping/SubmissionRequestMapper.cs
@@ -1,0 +1,27 @@
+// <copyright file="SubmissionRequestMapper.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Mapping;
+
+using ELearning.API.Models;
+using ELearning.Application.Submissions.Commands;
+
+internal static class SubmissionRequestMapper
+{
+    public static CreateSubmissionCommand ToCommand(this CreateSubmissionRequest request) =>
+        new()
+        {
+            AssignmentId = request.AssignmentId,
+            Content = request.Content ?? string.Empty,
+            FileUrl = request.FileUrl ?? string.Empty,
+        };
+
+    public static GradeSubmissionCommand ToCommand(this GradeSubmissionRequest request) =>
+        new()
+        {
+            SubmissionId = request.SubmissionId,
+            Score = request.Score,
+            Feedback = request.Feedback,
+        };
+}

--- a/ELearning.API/Models/CreateCourseRequest.cs
+++ b/ELearning.API/Models/CreateCourseRequest.cs
@@ -1,0 +1,22 @@
+// <copyright file="CreateCourseRequest.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Models;
+
+public sealed class CreateCourseRequest
+{
+    public string Title { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public int CategoryId { get; set; }
+
+    public int LevelId { get; set; }
+
+    public decimal Price { get; set; }
+
+    public int DurationHours { get; set; }
+
+    public int DurationMinutes { get; set; }
+}

--- a/ELearning.API/Models/CreateEnrollmentRequest.cs
+++ b/ELearning.API/Models/CreateEnrollmentRequest.cs
@@ -1,0 +1,10 @@
+// <copyright file="CreateEnrollmentRequest.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Models;
+
+public sealed class CreateEnrollmentRequest
+{
+    public Guid CourseId { get; set; }
+}

--- a/ELearning.API/Models/CreateSubmissionRequest.cs
+++ b/ELearning.API/Models/CreateSubmissionRequest.cs
@@ -1,0 +1,14 @@
+// <copyright file="CreateSubmissionRequest.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Models;
+
+public sealed class CreateSubmissionRequest
+{
+    public Guid AssignmentId { get; set; }
+
+    public string Content { get; set; } = string.Empty;
+
+    public string FileUrl { get; set; } = string.Empty;
+}

--- a/ELearning.API/Models/GradeSubmissionRequest.cs
+++ b/ELearning.API/Models/GradeSubmissionRequest.cs
@@ -1,0 +1,14 @@
+// <copyright file="GradeSubmissionRequest.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Models;
+
+public sealed class GradeSubmissionRequest
+{
+    public Guid SubmissionId { get; set; }
+
+    public int Score { get; set; }
+
+    public string Feedback { get; set; } = string.Empty;
+}

--- a/ELearning.API/Models/RejectCoursePublicationRequest.cs
+++ b/ELearning.API/Models/RejectCoursePublicationRequest.cs
@@ -1,0 +1,12 @@
+// <copyright file="RejectCoursePublicationRequest.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Models;
+
+public sealed class RejectCoursePublicationRequest
+{
+    public Guid CourseId { get; set; }
+
+    public string Reason { get; set; } = string.Empty;
+}

--- a/ELearning.API/Models/UpdateCourseRequest.cs
+++ b/ELearning.API/Models/UpdateCourseRequest.cs
@@ -1,0 +1,26 @@
+// <copyright file="UpdateCourseRequest.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Models;
+
+public sealed class UpdateCourseRequest
+{
+    public Guid CourseId { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public int CategoryId { get; set; }
+
+    public int LevelId { get; set; }
+
+    public decimal Price { get; set; }
+
+    public int DurationHours { get; set; }
+
+    public int DurationMinutes { get; set; }
+
+    public bool IsFeatured { get; set; }
+}

--- a/ELearning.API/Models/UpdateEnrollmentStatusRequest.cs
+++ b/ELearning.API/Models/UpdateEnrollmentStatusRequest.cs
@@ -1,0 +1,12 @@
+// <copyright file="UpdateEnrollmentStatusRequest.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.Models;
+
+public sealed class UpdateEnrollmentStatusRequest
+{
+    public Guid EnrollmentId { get; set; }
+
+    public string Status { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- Replaced REST request bodies that exposed Application command types with API-layer request DTOs.
- Kept command construction inside controllers.
- Preserved routes, authorization attributes, response shapes, ProblemDetails behavior, and route-id mismatch behavior.
- Refreshed ELearning.API.http with reviewer-facing REST examples and a small secondary GraphQL example.

## New request DTOs
- CreateCourseRequest
- UpdateCourseRequest
- RejectCoursePublicationRequest
- CreateEnrollmentRequest
- UpdateEnrollmentStatusRequest
- CreateSubmissionRequest
- GradeSubmissionRequest

## Updated endpoints
- POST /api/courses
- PUT /api/courses/{id}
- POST /api/courses/{id}/reject-publication
- POST /api/enrollments
- PUT /api/enrollments/{id}/status
- POST /api/submissions
- POST /api/submissions/{id}/grade

## Validation
- dotnet restore ELearning.sln passed
- dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false passed with 0 warnings and 0 errors
- dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false passed: 110 application tests and 55 integration tests
- dotnet list ELearning.sln package --vulnerable --include-transitive found no vulnerable packages

## Scope
No business behavior, domain logic, handlers, repositories, GraphQL, outbox, or notification logic changed.