### PR TITLE
Add GraphQL smoke and authorization coverage

### DIFF
--- a/ELearning.API/ELearning.API.csproj
+++ b/ELearning.API/ELearning.API.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageReference Include="HotChocolate" Version="15.1.14" />
     <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.14" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="15.1.14" />
     <PackageReference Include="HotChocolate.Data" Version="15.1.14" />
     <PackageReference Include="HotChocolate.Types" Version="15.1.14" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />

--- a/ELearning.API/GraphQL/GraphQLConfiguration.cs
+++ b/ELearning.API/GraphQL/GraphQLConfiguration.cs
@@ -20,6 +20,7 @@ public static class GraphQLConfiguration
             .AddType<InstructorType>()
             .AddType<EnrollmentType>()
             .AddType<SubmissionType>()
+            .AddAuthorization()
             .AddFiltering()
             .AddSorting()
             .AddProjections();

--- a/ELearning.API/GraphQL/Mutation.cs
+++ b/ELearning.API/GraphQL/Mutation.cs
@@ -12,8 +12,8 @@ using ELearning.Application.Common.Model;
 using ELearning.Application.Courses.Commands;
 using ELearning.Application.Enrollments.Commands;
 using ELearning.Application.Submissions.Commands;
+using HotChocolate.Authorization;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 
 /// <summary>
 /// GraphQL mutation root type.
@@ -22,7 +22,7 @@ using Microsoft.AspNetCore.Authorization;
 public class Mutation(ILogger<Mutation> logger)
 {
     [GraphQLDescription("Create a new course")]
-    [Authorize(Roles = "Instructor")]
+    [Authorize(Roles = new[] { "Instructor" })]
     public async Task<CoursePayload> CreateCourse(
         [Service] IMediator mediator,
         CreateCourseInput input)
@@ -49,7 +49,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Enroll in a course")]
-    [Authorize(Roles = "Student")]
+    [Authorize(Roles = new[] { "Student" })]
     public async Task<EnrollmentPayload> CreateEnrollment(
         [Service] IMediator mediator,
         CreateEnrollmentInput input)
@@ -64,7 +64,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Submit an assignment")]
-    [Authorize(Roles = "Student")]
+    [Authorize(Roles = new[] { "Student" })]
     public async Task<SubmissionPayload> CreateSubmission(
         [Service] IMediator mediator,
         CreateSubmissionInput input)
@@ -81,7 +81,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Grade a submission")]
-    [Authorize(Roles = "Instructor,Admin")]
+    [Authorize(Roles = new[] { "Instructor", "Admin" })]
     public async Task<GradeSubmissionPayload> GradeSubmission(
         [Service] IMediator mediator,
         GradeSubmissionInput input)
@@ -98,7 +98,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Update an existing course")]
-    [Authorize(Roles = "Instructor")]
+    [Authorize(Roles = new[] { "Instructor" })]
     public async Task<OperationPayload> UpdateCourse(
         [Service] IMediator mediator,
         UpdateCourseInput input)
@@ -121,7 +121,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Add a module to a course")]
-    [Authorize(Roles = "Instructor")]
+    [Authorize(Roles = new[] { "Instructor" })]
     public async Task<OperationPayload> AddCourseModule(
         [Service] IMediator mediator,
         AddCourseModuleInput input,
@@ -140,7 +140,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Add a lesson to a course module")]
-    [Authorize(Roles = "Instructor")]
+    [Authorize(Roles = new[] { "Instructor" })]
     public async Task<OperationPayload> AddCourseLesson(
         [Service] IMediator mediator,
         AddCourseLessonInput input,
@@ -164,7 +164,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Add an assignment to a course module")]
-    [Authorize(Roles = "Instructor")]
+    [Authorize(Roles = new[] { "Instructor" })]
     public async Task<OperationPayload> AddCourseAssignment(
         [Service] IMediator mediator,
         AddCourseAssignmentInput input,
@@ -186,7 +186,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Delete a course")]
-    [Authorize(Roles = "Instructor,Admin")]
+    [Authorize(Roles = new[] { "Instructor", "Admin" })]
     public async Task<OperationPayload> DeleteCourse(
         [Service] IMediator mediator,
         Guid courseId)
@@ -198,7 +198,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Submit a course for admin review")]
-    [Authorize(Roles = "Instructor")]
+    [Authorize(Roles = new[] { "Instructor" })]
     public async Task<OperationPayload> SubmitCourseForReview(
         [Service] IMediator mediator,
         Guid courseId)
@@ -210,7 +210,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Approve a course for publication")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = new[] { "Admin" })]
     public async Task<OperationPayload> ApproveCoursePublication(
         [Service] IMediator mediator,
         Guid courseId)
@@ -222,7 +222,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Reject a course review submission")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = new[] { "Admin" })]
     public async Task<OperationPayload> RejectCoursePublication(
         [Service] IMediator mediator,
         Guid courseId,
@@ -235,7 +235,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Archive a course")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = new[] { "Admin" })]
     public async Task<OperationPayload> ArchiveCourse(
         [Service] IMediator mediator,
         Guid courseId)
@@ -247,7 +247,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Mark a lesson as started for an enrolled student")]
-    [Authorize(Roles = "Student")]
+    [Authorize(Roles = new[] { "Student" })]
     public async Task<OperationPayload> StartLesson(
         [Service] IMediator mediator,
         Guid enrollmentId,
@@ -260,7 +260,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Mark a lesson as completed for an enrolled student")]
-    [Authorize(Roles = "Student")]
+    [Authorize(Roles = new[] { "Student" })]
     public async Task<OperationPayload> CompleteLesson(
         [Service] IMediator mediator,
         Guid enrollmentId,
@@ -273,7 +273,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Submit a review for a completed enrollment")]
-    [Authorize(Roles = "Student")]
+    [Authorize(Roles = new[] { "Student" })]
     public async Task<OperationPayload> ReviewCourse(
         [Service] IMediator mediator,
         Guid enrollmentId,
@@ -287,7 +287,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Issue or retrieve the certificate for a completed enrollment")]
-    [Authorize(Roles = "Student,Admin")]
+    [Authorize(Roles = new[] { "Student", "Admin" })]
     public async Task<CertificatePayload> IssueEnrollmentCertificate(
         [Service] IMediator mediator,
         Guid enrollmentId)
@@ -299,7 +299,7 @@ public class Mutation(ILogger<Mutation> logger)
     }
 
     [GraphQLDescription("Pause, resume, or abandon an enrollment without affecting completion rules")]
-    [Authorize(Roles = "Student,Admin")]
+    [Authorize(Roles = new[] { "Student", "Admin" })]
     public async Task<OperationPayload> UpdateEnrollmentStatus(
         [Service] IMediator mediator,
         UpdateEnrollmentStatusInput input)

--- a/ELearning.API/GraphQL/Payloads/Error.cs
+++ b/ELearning.API/GraphQL/Payloads/Error.cs
@@ -1,0 +1,12 @@
+// <copyright file="Error.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.API.GraphQL.Payloads;
+
+[GraphQLDescription("A GraphQL payload error")]
+public sealed record Error(
+    [property: GraphQLDescription("Stable error code")]
+    string Code,
+    [property: GraphQLDescription("Human-readable error message")]
+    string Message);

--- a/ELearning.API/GraphQL/Payloads/PayloadBase.cs
+++ b/ELearning.API/GraphQL/Payloads/PayloadBase.cs
@@ -16,7 +16,6 @@ public abstract class PayloadBase
     public bool IsSuccess => !this.errors.Any();
 
     [GraphQLDescription("List of errors that occurred during the operation")]
-    [UseFiltering]
     public IReadOnlyList<Error> Errors => this.errors.AsReadOnly();
 
     protected PayloadBase()

--- a/ELearning.API/GraphQL/Query.cs
+++ b/ELearning.API/GraphQL/Query.cs
@@ -16,8 +16,8 @@ using ELearning.Application.Students.Dtos;
 using ELearning.Application.Students.Queries;
 using ELearning.Application.Submissions.Dtos;
 using ELearning.Application.Submissions.Queries;
+using HotChocolate.Authorization;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 
 /// <summary>
 /// GraphQL query root type.
@@ -181,7 +181,7 @@ public class Query
     [UseFiltering]
     [UseSorting]
     [GraphQLDescription("Get pending submissions for an instructor")]
-    [Authorize(Roles = "Instructor")]
+    [Authorize(Roles = new[] { "Instructor" })]
     public async Task<IEnumerable<SubmissionDto>> GetPendingSubmissions(
         [Service] IMediator mediator,
         Guid instructorId,

--- a/ELearning.Application/Courses/ReadModels/CourseReadModel.cs
+++ b/ELearning.Application/Courses/ReadModels/CourseReadModel.cs
@@ -4,6 +4,8 @@
 
 namespace ELearning.Application.Courses.ReadModels;
 
+using System.Globalization;
+
 public sealed record CourseReadModel(
     Guid Id,
     string Title,
@@ -20,5 +22,38 @@ public sealed record CourseReadModel(
     int DurationMinutes,
     int EnrollmentsCount)
 {
+    public CourseReadModel(
+        string Id,
+        string Title,
+        string Description,
+        string InstructorFirstName,
+        string InstructorLastName,
+        long CategoryId,
+        long LevelId,
+        string Price,
+        string AverageRating,
+        long NumberOfRatings,
+        long IsFeatured,
+        long DurationHours,
+        long DurationMinutes,
+        long EnrollmentsCount)
+        : this(
+            Guid.Parse(Id),
+            Title,
+            Description,
+            InstructorFirstName,
+            InstructorLastName,
+            checked((int)CategoryId),
+            checked((int)LevelId),
+            decimal.Parse(Price, NumberStyles.Number, CultureInfo.InvariantCulture),
+            decimal.Parse(AverageRating, NumberStyles.Number, CultureInfo.InvariantCulture),
+            checked((int)NumberOfRatings),
+            IsFeatured != 0,
+            checked((int)DurationHours),
+            checked((int)DurationMinutes),
+            checked((int)EnrollmentsCount))
+    {
+    }
+
     public string InstructorName => $"{this.InstructorFirstName} {this.InstructorLastName}".Trim();
 }

--- a/ELearning.IntegrationTests/GraphQLIntegrationTests.cs
+++ b/ELearning.IntegrationTests/GraphQLIntegrationTests.cs
@@ -1,0 +1,333 @@
+// <copyright file="GraphQLIntegrationTests.cs" company="FarazLoloei">
+// Copyright (c) FarazLoloei. All rights reserved.
+// </copyright>
+
+namespace ELearning.IntegrationTests;
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using ELearning.Application.Auth.Abstractions;
+using ELearning.Domain.Entities.CourseAggregate;
+using ELearning.Domain.Entities.CourseAggregate.Enums;
+using ELearning.Domain.Entities.UserAggregate;
+using ELearning.Domain.ValueObjects;
+using ELearning.Infrastructure.Data;
+using ELearning.IntegrationTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+public sealed class GraphQLIntegrationTests : IClassFixture<RealAuthWebApplicationFactory>
+{
+    private const string JwtIssuer = "integration-tests";
+    private const string JwtAudience = "integration-tests";
+    private const string JwtSecret = "integration-tests-secret-key-with-32chars";
+
+    private readonly RealAuthWebApplicationFactory factory;
+    private readonly HttpClient client;
+
+    public GraphQLIntegrationTests(RealAuthWebApplicationFactory factory)
+    {
+        this.factory = factory;
+        this.client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task PublicCoursesQuery_ReturnsPublishedCoursesShape()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var title = await this.SeedPublishedCourseAsync(cancellationToken);
+        var query = $$"""
+            query {
+              courses(searchTerm: "{{title}}", first: 10) {
+                nodes {
+                  id
+                  title
+                  instructorName
+                  category
+                  level
+                }
+              }
+            }
+            """;
+
+        var response = await this.PostGraphQlAsync(query, token: null, cancellationToken);
+
+        using var document = await AssertGraphQlOkAsync(response, cancellationToken);
+        var root = document.RootElement;
+        AssertNoGraphQlErrors(root);
+
+        var nodes = root
+            .GetProperty("data")
+            .GetProperty("courses")
+            .GetProperty("nodes")
+            .EnumerateArray()
+            .ToArray();
+
+        nodes.Should().ContainSingle(node =>
+            node.GetProperty("title").GetString() == title &&
+            !string.IsNullOrWhiteSpace(node.GetProperty("id").GetString()) &&
+            node.GetProperty("instructorName").GetString() == "GraphQL Instructor" &&
+            node.GetProperty("category").GetString() == CourseCategory.Programming.Name &&
+            node.GetProperty("level").GetString() == CourseLevel.Beginner.Name);
+    }
+
+    [Fact]
+    public async Task ProtectedQueryWithoutToken_ReturnsGraphQlAuthorizationError()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var studentId = Guid.NewGuid();
+        var query = $$"""
+            query {
+              studentProgress(studentId: "{{studentId}}") {
+                studentId
+                studentName
+                completedCourses
+                inProgressCourses
+              }
+            }
+            """;
+
+        var response = await this.PostGraphQlAsync(query, token: null, cancellationToken);
+
+        using var document = await AssertGraphQlOkAsync(response, cancellationToken);
+        AssertGraphQlAuthorizationError(document.RootElement, "AUTH_NOT_AUTHENTICATED");
+    }
+
+    [Fact]
+    public async Task InstructorMutationWithStudentToken_ReturnsGraphQlAuthorizationError()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var studentId = await this.SeedStudentAsync(cancellationToken);
+        var title = CreateUniqueTitle("wrong-role");
+        var query = $$"""
+            mutation {
+              createCourse(input: {
+                title: "{{title}}"
+                description: "GraphQL wrong-role mutation should be blocked before resolver execution."
+                categoryId: 1
+                levelId: 1
+                price: 0
+                durationHours: 1
+                durationMinutes: 0
+              }) {
+                isSuccess
+                errors {
+                  code
+                  message
+                }
+              }
+            }
+            """;
+
+        var response = await this.PostGraphQlAsync(query, CreateJwt(studentId, "Student"), cancellationToken);
+
+        using var document = await AssertGraphQlOkAsync(response, cancellationToken);
+        AssertGraphQlAuthorizationError(document.RootElement, "AUTH_NOT_AUTHORIZED");
+    }
+
+    [Fact]
+    public async Task CreateCourseMutationWithInstructorToken_ReturnsSuccessAndPersistsDraftCourse()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var instructorId = await this.SeedInstructorAsync(cancellationToken);
+        var title = CreateUniqueTitle("happy-path");
+        var query = $$"""
+            mutation {
+              createCourse(input: {
+                title: "{{title}}"
+                description: "GraphQL happy-path mutation smoke test course."
+                categoryId: 1
+                levelId: 1
+                price: 0
+                durationHours: 1
+                durationMinutes: 0
+              }) {
+                isSuccess
+                errors {
+                  code
+                  message
+                }
+              }
+            }
+            """;
+
+        var response = await this.PostGraphQlAsync(query, CreateJwt(instructorId, "Instructor"), cancellationToken);
+
+        using var document = await AssertGraphQlOkAsync(response, cancellationToken);
+        var root = document.RootElement;
+        AssertNoGraphQlErrors(root);
+
+        var payload = root
+            .GetProperty("data")
+            .GetProperty("createCourse");
+
+        payload.GetProperty("isSuccess").GetBoolean().Should().BeTrue();
+        payload.GetProperty("errors").EnumerateArray().Should().BeEmpty();
+
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var course = await dbContext.Courses.SingleAsync(course => course.Title == title, cancellationToken);
+        course.InstructorId.Should().Be(instructorId);
+        course.Status.Should().Be(CourseStatus.Draft);
+    }
+
+    private async Task<HttpResponseMessage> PostGraphQlAsync(
+        string query,
+        string? token,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/graphql")
+        {
+            Content = JsonContent.Create(new { query }),
+        };
+
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return await this.client.SendAsync(request, cancellationToken);
+    }
+
+    private async Task<string> SeedPublishedCourseAsync(CancellationToken cancellationToken)
+    {
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
+        var uniqueValue = Guid.NewGuid().ToString("N");
+
+        var instructor = new Instructor(
+            firstName: "GraphQL",
+            lastName: "Instructor",
+            email: Email.Create($"graphql.instructor.{uniqueValue}@tests.io"),
+            passwordHash: passwordHasher.HashPassword("P@ssword123!"),
+            bio: "Builds GraphQL smoke tests.",
+            expertise: "Backend engineering");
+
+        var title = CreateUniqueTitle("public-query");
+        var course = new Course(
+            title,
+            "A published course seeded for GraphQL public query coverage.",
+            instructor.Id,
+            CourseCategory.Programming,
+            CourseLevel.Beginner,
+            Duration.Create(1, 0),
+            0m);
+
+        course.AddModule(new Module(
+            "GraphQL module",
+            "Module required before publication.",
+            1,
+            course.Id));
+        course.SubmitForReview();
+        course.ApprovePublication();
+
+        dbContext.Instructors.Add(instructor);
+        dbContext.Courses.Add(course);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return title;
+    }
+
+    private async Task<Guid> SeedInstructorAsync(CancellationToken cancellationToken)
+    {
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
+        var uniqueValue = Guid.NewGuid().ToString("N");
+
+        var instructor = new Instructor(
+            firstName: "GraphQL",
+            lastName: "Instructor",
+            email: Email.Create($"graphql.course.author.{uniqueValue}@tests.io"),
+            passwordHash: passwordHasher.HashPassword("P@ssword123!"),
+            bio: "Builds GraphQL mutation tests.",
+            expertise: "Backend engineering");
+
+        dbContext.Instructors.Add(instructor);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return instructor.Id;
+    }
+
+    private async Task<Guid> SeedStudentAsync(CancellationToken cancellationToken)
+    {
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
+        var uniqueValue = Guid.NewGuid().ToString("N");
+
+        var student = new Student(
+            firstName: "GraphQL",
+            lastName: "Student",
+            email: Email.Create($"graphql.student.{uniqueValue}@tests.io"),
+            passwordHash: passwordHasher.HashPassword("P@ssword123!"));
+
+        dbContext.Students.Add(student);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return student.Id;
+    }
+
+    private static async Task<JsonDocument> AssertGraphQlOkAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            await response.Content.ReadAsStringAsync(cancellationToken));
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken);
+    }
+
+    private static void AssertNoGraphQlErrors(JsonElement root)
+    {
+        root.TryGetProperty("errors", out _).Should().BeFalse(root.GetRawText());
+    }
+
+    private static void AssertGraphQlAuthorizationError(JsonElement root, string expectedCode)
+    {
+        root.TryGetProperty("errors", out var errors).Should().BeTrue(root.GetRawText());
+        errors.ValueKind.Should().Be(JsonValueKind.Array);
+        errors.GetArrayLength().Should().BeGreaterThan(0);
+
+        var error = errors.EnumerateArray().First();
+        error.TryGetProperty("message", out var message).Should().BeTrue(root.GetRawText());
+        message.GetString().Should().NotBeNullOrWhiteSpace();
+
+        error.TryGetProperty("extensions", out var extensions).Should().BeTrue(root.GetRawText());
+        extensions.TryGetProperty("code", out var code).Should().BeTrue(root.GetRawText());
+        code.GetString().Should().Be(expectedCode);
+    }
+
+    private static string CreateUniqueTitle(string prefix) =>
+        $"GraphQL {prefix} {Guid.NewGuid():N}";
+
+    private static string CreateJwt(Guid userId, string role)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+            new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new Claim(ClaimTypes.Role, role),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: JwtIssuer,
+            audience: JwtAudience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
## Summary
- Added focused GraphQL integration tests for the /graphql endpoint.
- Covered public query smoke test, protected query without token, wrong-role mutation denial, and instructor happy-path createCourse mutation.
- Registered HotChocolate authorization so GraphQL authorization is enforced correctly.
- Replaced leaked HotChocolate internal Error payload type with a simple API payload error type.
- Fixed SQLite/Dapper CourseReadModel materialization for public course query scenarios.

## Validation
- dotnet restore ELearning.sln passed
- dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false passed with 0 warnings and 0 errors
- dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false passed: 110 application tests and 59 integration tests
- dotnet list ELearning.sln package --vulnerable --include-transitive found no vulnerable packages

## Scope
GraphQL remains a secondary API surface. No REST contracts, domain behavior, outbox, RabbitMQ, notifications, Docker, or Kubernetes behavior changed.