### PR TITLE
Fix instructor read model and smoke test ID recovery

### DIFF
--- a/ELearning.Infrastructure/Data/Repositories/InstructorReadRepository.cs
+++ b/ELearning.Infrastructure/Data/Repositories/InstructorReadRepository.cs
@@ -5,6 +5,7 @@
 namespace ELearning.Infrastructure.Data.Repositories;
 
 using System.Data;
+using System.Globalization;
 using Dapper;
 using ELearning.Application.Instructors.ReadModels;
 using ELearning.Domain.Entities.UserAggregate.Abstractions.Repositories;
@@ -142,7 +143,7 @@ public class InstructorReadRepository(ApplicationDbContext context, ISqlDialect 
                                      GROUP BY u.Id, u.FirstName, u.LastName, u.Email, u.Bio, u.Expertise, u.ProfilePictureUrl
                                      """;
 
-        var instructor = await connection.QuerySingleOrDefaultAsync<InstructorSummaryRow>(
+        var instructor = await connection.QuerySingleOrDefaultAsync(
             new CommandDefinition(instructorSql, new { InstructorId = instructorId }, cancellationToken: cancellationToken));
 
         if (instructor is null)
@@ -155,8 +156,8 @@ public class InstructorReadRepository(ApplicationDbContext context, ISqlDialect 
                                          c.Title,
                                          c.Category AS CategoryId,
                                          c.Status AS StatusId,
-                                         c.PublishedDate,
-                                         c.createdAtUTC AS CreatedAt,
+                                         c.PublishedDate AS PublishedDate,
+                                         c.createdAtUTC AS CreatedAtUtc,
                                          COUNT(DISTINCT e.StudentId) AS EnrollmentsCount
                                   FROM Courses c
                                   LEFT JOIN Enrollments e ON e.CourseId = c.Id
@@ -165,22 +166,29 @@ public class InstructorReadRepository(ApplicationDbContext context, ISqlDialect 
                                   ORDER BY c.createdAtUTC DESC
                                   """;
 
-        var courses = await connection.QueryAsync<InstructorCourseRow>(
+        var courses = await connection.QueryAsync(
             new CommandDefinition(coursesSql, new { InstructorId = instructorId }, cancellationToken: cancellationToken));
 
-        var courseReadModels = courses.Select(MapToInstructorCourseReadModel).ToList();
+        var courseReadModels = courses.Select(row => new InstructorCourseReadModel(
+            ReadGuid(row.Id),
+            ReadString(row.Title),
+            ReadInt32(row.CategoryId),
+            ReadInt32(row.EnrollmentsCount),
+            ReadInt32(row.StatusId),
+            ReadNullableDateTime(row.PublishedDate),
+            ReadDateTime(row.CreatedAtUtc))).ToList();
 
         return new InstructorWithCoursesReadModel(
-            instructor.Id,
-            instructor.FirstName,
-            instructor.LastName,
-            instructor.Email,
-            instructor.Bio,
-            instructor.Expertise,
-            instructor.ProfilePictureUrl ?? string.Empty,
-            CalculateAverageRating(instructor.WeightedRatingsSum, instructor.TotalRatingsCount),
-            instructor.TotalStudents,
-            instructor.TotalCourses,
+            ReadGuid(instructor.Id),
+            ReadString(instructor.FirstName),
+            ReadString(instructor.LastName),
+            ReadString(instructor.Email),
+            ReadString(instructor.Bio),
+            ReadString(instructor.Expertise),
+            ReadNullableString(instructor.ProfilePictureUrl),
+            CalculateAverageRating(ReadDecimal(instructor.WeightedRatingsSum), ReadInt32(instructor.TotalRatingsCount)),
+            ReadInt32(instructor.TotalStudents),
+            ReadInt32(instructor.TotalCourses),
             courseReadModels);
     }
 
@@ -248,18 +256,39 @@ public class InstructorReadRepository(ApplicationDbContext context, ISqlDialect 
             row.TotalStudents,
             row.TotalCourses);
 
-    private static InstructorCourseReadModel MapToInstructorCourseReadModel(InstructorCourseRow row) =>
-        new(
-            row.Id,
-            row.Title,
-            row.CategoryId,
-            row.EnrollmentsCount,
-            row.StatusId,
-            row.PublishedDate,
-            row.CreatedAt);
-
     private static decimal CalculateAverageRating(decimal weightedRatingsSum, int totalRatingsCount) =>
         totalRatingsCount == 0 ? 0 : weightedRatingsSum / totalRatingsCount;
+
+    private static Guid ReadGuid(object value) =>
+        value switch
+        {
+            Guid guid => guid,
+            string text => Guid.Parse(text),
+            _ => Guid.Parse(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty),
+        };
+
+    private static string ReadString(object? value) =>
+        value?.ToString() ?? string.Empty;
+
+    private static string? ReadNullableString(object? value) =>
+        value?.ToString();
+
+    private static int ReadInt32(object value) =>
+        Convert.ToInt32(value, CultureInfo.InvariantCulture);
+
+    private static decimal ReadDecimal(object value) =>
+        Convert.ToDecimal(value, CultureInfo.InvariantCulture);
+
+    private static DateTime ReadDateTime(object value) =>
+        value switch
+        {
+            DateTime dateTime => dateTime,
+            string text => DateTime.Parse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+            _ => Convert.ToDateTime(value, CultureInfo.InvariantCulture),
+        };
+
+    private static DateTime? ReadNullableDateTime(object? value) =>
+        value is null or DBNull ? null : ReadDateTime(value);
 
     private sealed record InstructorSummaryRow(
         Guid Id,
@@ -273,15 +302,6 @@ public class InstructorReadRepository(ApplicationDbContext context, ISqlDialect 
         int TotalStudents,
         decimal WeightedRatingsSum,
         int TotalRatingsCount);
-
-    private sealed record InstructorCourseRow(
-        Guid Id,
-        string Title,
-        int CategoryId,
-        int StatusId,
-        DateTime CreatedAt,
-        DateTime? PublishedDate,
-        int EnrollmentsCount);
 
     private sealed record RatingRow(decimal Rating, int RatingCount);
 }

--- a/ELearning.IntegrationTests/CourseAuthoringWorkflowIntegrationTests.cs
+++ b/ELearning.IntegrationTests/CourseAuthoringWorkflowIntegrationTests.cs
@@ -59,6 +59,29 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
     }
 
     [Fact]
+    public async Task GetInstructorWithCourses_ReturnsCreatedDraftCourse()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var instructorId = await this.SeedInstructorAsync(cancellationToken);
+        var title = CreateUniqueTitle("with-courses");
+        var courseId = await this.CreateCourseAsync(instructorId, title, cancellationToken);
+
+        var response = await this.client.GetAsync($"/api/instructors/{instructorId}/with-courses", cancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var content = await JsonDocument.ParseAsync(responseStream, cancellationToken: cancellationToken);
+        content.RootElement.GetProperty("succeeded").GetBoolean().Should().BeTrue();
+
+        var courses = content.RootElement.GetProperty("data").GetProperty("courses");
+        courses.EnumerateArray()
+            .Any(course => course.GetProperty("id").GetGuid() == courseId && course.GetProperty("title").GetString() == title)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
     public async Task CourseCannotBeSubmittedWithoutContent_ReturnsConflict()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/postman/ELearning-Manual-Smoke.postman_collection.json
+++ b/postman/ELearning-Manual-Smoke.postman_collection.json
@@ -432,7 +432,10 @@
                 "exec": [
                   "if (!pm.environment.get('uniqueCourseTitle')) {",
                   "  pm.environment.set('uniqueCourseTitle', `REST Smoke ${Date.now()}`);",
-                  "}"
+                  "}",
+                  "['courseId', 'courseStatus', 'moduleId', 'lessonId', 'assignmentId', 'enrollmentCreated', 'enrollmentId', 'submissionId', 'certificateCode'].forEach(function (key) {",
+                  "  pm.environment.unset(key);",
+                  "});"
                 ]
               }
             },
@@ -444,10 +447,17 @@
                   "pm.test('Status is 201', function () {",
                   "  pm.response.to.have.status(201);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
-                  "pm.test('Create course does not return data payload', function () {",
-                  "  pm.expect(body.data).to.eql(null);",
+                  "pm.test('Create course does not require a created ID in the response body', function () {",
+                  "  pm.expect(body.data === null || typeof body.data === 'undefined').to.eql(true);",
                   "});"
                 ]
               }
@@ -488,6 +498,21 @@
           "name": "GET /api/v1/instructors/{{instructorId}}/with-courses",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['instructorId', 'uniqueCourseTitle'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -495,7 +520,14 @@
                   "pm.test('Status is 200', function () {",
                   "  pm.response.to.have.status(200);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "const courses = (body.data && body.data.courses) || [];",
                   "const match = courses.find(c => c.title === pm.environment.get('uniqueCourseTitle'));",
@@ -504,6 +536,9 @@
                   "});",
                   "if (match) {",
                   "  pm.environment.set('courseId', match.id);",
+                  "  if (match.status) {",
+                  "    pm.environment.set('courseStatus', match.status);",
+                  "  }",
                   "}"
                 ]
               }
@@ -538,6 +573,21 @@
           "name": "POST /api/v1/courses/{{courseId}}/modules",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -545,7 +595,14 @@
                   "pm.test('Status is 201', function () {",
                   "  pm.response.to.have.status(201);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "pm.environment.set('moduleId', body.data);"
                 ]
@@ -588,6 +645,21 @@
           "name": "POST /api/v1/courses/{{courseId}}/modules/{{moduleId}}/lessons",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId', 'moduleId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -595,7 +667,14 @@
                   "pm.test('Status is 201', function () {",
                   "  pm.response.to.have.status(201);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "pm.environment.set('lessonId', body.data);"
                 ]
@@ -640,6 +719,21 @@
           "name": "POST /api/v1/courses/{{courseId}}/modules/{{moduleId}}/assignments",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId', 'moduleId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -647,7 +741,14 @@
                   "pm.test('Status is 201', function () {",
                   "  pm.response.to.have.status(201);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "pm.environment.set('assignmentId', body.data);"
                 ]
@@ -692,6 +793,21 @@
           "name": "POST /api/v1/courses/{{courseId}}/submit-for-review",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -699,7 +815,14 @@
                   "pm.test('Status is 200', function () {",
                   "  pm.response.to.have.status(200);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -733,6 +856,26 @@
           "name": "GET /api/v1/courses/{{courseId}}",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const courseStatus = pm.environment.get('courseStatus');",
+                  "const missing = ['courseId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0 || courseStatus !== 'Published') {",
+                  "  const reasons = missing.slice();",
+                  "  if (courseStatus !== 'Published') {",
+                  "    reasons.push(`courseStatus=${courseStatus || 'missing'} (published course required)`);",
+                  "  }",
+                  "  console.warn(`Skipping request because prerequisites are not satisfied: ${reasons.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -740,7 +883,14 @@
                   "pm.test('Status is 200 for owner view', function () {",
                   "  pm.response.to.have.status(200);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -782,6 +932,43 @@
       "item": [
         {
           "name": "POST /api/v1/courses/{{courseId}}/approve-publication",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId', 'adminToken'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "  const body = (() => {",
+                  "    try {",
+                  "      return pm.response.json();",
+                  "    } catch (error) {",
+                  "      return null;",
+                  "    }",
+                  "  })();",
+                  "  if (body && body.succeeded === true) {",
+                  "    pm.environment.set('courseStatus', 'Published');",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
           "request": {
             "method": "POST",
             "header": [
@@ -812,6 +999,43 @@
         },
         {
           "name": "POST /api/v1/courses/{{courseId}}/reject-publication",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId', 'adminToken'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "  const body = (() => {",
+                  "    try {",
+                  "      return pm.response.json();",
+                  "    } catch (error) {",
+                  "      return null;",
+                  "    }",
+                  "  })();",
+                  "  if (body && body.succeeded === true) {",
+                  "    pm.environment.set('courseStatus', 'Rejected');",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
           "request": {
             "method": "POST",
             "header": [
@@ -854,6 +1078,26 @@
           "name": "POST /api/v1/enrollments",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const courseStatus = pm.environment.get('courseStatus');",
+                  "const missing = ['courseId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0 || courseStatus !== 'Published') {",
+                  "  const reasons = missing.slice();",
+                  "  if (courseStatus !== 'Published') {",
+                  "    reasons.push(`courseStatus=${courseStatus || 'missing'} (published course required)`);",
+                  "  }",
+                  "  console.warn(`Skipping request because prerequisites are not satisfied: ${reasons.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -861,9 +1105,21 @@
                   "pm.test('Status is 201', function () {",
                   "  pm.response.to.have.status(201);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
-                  "pm.expect(body.data).to.eql(null);"
+                  "if (pm.response.code === 201) {",
+                  "  pm.environment.set('enrollmentCreated', 'true');",
+                  "}",
+                  "pm.test('Create enrollment does not require a created ID in the response body', function () {",
+                  "  pm.expect(body.data === null || typeof body.data === 'undefined').to.eql(true);",
+                  "});"
                 ]
               }
             }
@@ -903,6 +1159,30 @@
           "name": "GET /api/v1/students/{{studentId}}/enrollments",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const courseStatus = pm.environment.get('courseStatus');",
+                  "const enrollmentCreated = pm.environment.get('enrollmentCreated');",
+                  "const missing = ['studentId', 'courseId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0 || courseStatus !== 'Published' || enrollmentCreated !== 'true') {",
+                  "  const reasons = missing.slice();",
+                  "  if (courseStatus !== 'Published') {",
+                  "    reasons.push(`courseStatus=${courseStatus || 'missing'} (published course required)`);",
+                  "  }",
+                  "  if (enrollmentCreated !== 'true') {",
+                  "    reasons.push('enrollment was not created');",
+                  "  }",
+                  "  console.warn(`Skipping request because prerequisites are not satisfied: ${reasons.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -910,7 +1190,14 @@
                   "pm.test('Status is 200', function () {",
                   "  pm.response.to.have.status(200);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "const items = (body.data && body.data.items) || [];",
                   "const match = items.find(e => e.courseId === pm.environment.get('courseId'));",
@@ -966,6 +1253,21 @@
           "name": "GET /api/v1/enrollments/{{enrollmentId}}",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['enrollmentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
@@ -973,7 +1275,14 @@
                   "pm.test('Status is 200', function () {",
                   "  pm.response.to.have.status(200);",
                   "});",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "const submissions = (body.data && body.data.submissions) || [];",
                   "const match = submissions.find(s => s.assignmentId === pm.environment.get('assignmentId'));",
@@ -1015,12 +1324,34 @@
           "name": "POST /api/v1/enrollments/{{enrollmentId}}/lessons/{{lessonId}}/start",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['enrollmentId', 'lessonId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -1056,12 +1387,34 @@
           "name": "POST /api/v1/enrollments/{{enrollmentId}}/lessons/{{lessonId}}/complete",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['enrollmentId', 'lessonId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -1097,14 +1450,38 @@
           "name": "POST /api/v1/submissions",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['assignmentId', 'enrollmentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(201);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
-                  "pm.expect(body.data).to.eql(null);"
+                  "pm.test('Create submission does not require a created ID in the response body', function () {",
+                  "  pm.expect(body.data === null || typeof body.data === 'undefined').to.eql(true);",
+                  "});"
                 ]
               }
             }
@@ -1143,12 +1520,34 @@
           "name": "GET /api/v1/enrollments/{{enrollmentId}} (Recover submissionId)",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['enrollmentId', 'assignmentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "const submissions = (body.data && body.data.submissions) || [];",
                   "const match = submissions.find(s => s.assignmentId === pm.environment.get('assignmentId'));",
@@ -1193,12 +1592,34 @@
           "name": "GET /api/v1/students/{{studentId}}/progress",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['studentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -1241,12 +1662,34 @@
           "name": "GET /api/v1/instructors/{{instructorId}}/pending-submissions",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['instructorId', 'assignmentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "const items = (body.data && body.data.items) || [];",
                   "const match = items.find(s => s.assignmentId === pm.environment.get('assignmentId'));",
@@ -1299,12 +1742,34 @@
           "name": "POST /api/v1/submissions/{{submissionId}}/grade",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['submissionId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -1346,12 +1811,34 @@
           "name": "GET /api/v1/submissions/{{submissionId}}",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['submissionId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -1388,12 +1875,34 @@
           "name": "POST /api/v1/enrollments/{{enrollmentId}}/review",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['enrollmentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
@@ -1436,12 +1945,34 @@
           "name": "POST /api/v1/certificates/enrollments/{{enrollmentId}}/issue",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['enrollmentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "if (body.data && body.data.certificateCode) {",
                   "  pm.environment.set('certificateCode', body.data.certificateCode);",
@@ -1479,12 +2010,34 @@
           "name": "GET /api/v1/certificates/enrollments/{{enrollmentId}}",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['enrollmentId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "if (body.data && body.data.certificateCode) {",
                   "  pm.environment.set('certificateCode', body.data.certificateCode);",
@@ -1525,12 +2078,34 @@
           "name": "GET /api/v1/certificates/verify/{{certificateCode}}",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['certificateCode'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "type": "text/javascript",
                 "exec": [
                   "pm.response.to.have.status(200);",
-                  "const body = pm.response.json();",
+                  "const body = (() => {",
+                  "  try {",
+                  "    return pm.response.json();",
+                  "  } catch (error) {",
+                  "    return null;",
+                  "  }",
+                  "})();",
+                  "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
                   "if (body.data && body.data.certificateCode) {",
                   "  pm.environment.set('certificateCode', body.data.certificateCode);",
@@ -1656,6 +2231,23 @@
         },
         {
           "name": "POST /api/v1/courses/{{courseId}}/submit-for-review (Optional Draft Rule Check)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
           "request": {
             "method": "POST",
             "header": [
@@ -1683,6 +2275,23 @@
         },
         {
           "name": "PUT /api/v1/courses/{{courseId}} (Optional Route/Body Mismatch)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const missing = ['courseId'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because required environment values are missing: ${missing.join(', ')}`);",
+                  "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "    pm.execution.skipRequest();",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
           "request": {
             "method": "PUT",
             "header": [


### PR DESCRIPTION
## Summary

This PR fixes the local manual smoke-test flow for the E-Learning API when running against the Docker Compose SQL Server/RabbitMQ stack.

The main issue was that some create endpoints intentionally return `201 Created` without exposing the created ID in the response body. The Postman collection previously expected IDs directly from those responses, so dependent requests were sent with empty route parameters such as `/courses//modules` and `/enrollments/`.

This PR keeps the existing REST create-response contracts unchanged and updates the smoke flow to recover required IDs from existing read endpoints.

## Changes

* Fixed `GET /api/v1/instructors/{instructorId}/with-courses` by replacing brittle Dapper constructor mapping with explicit provider-safe row mapping.
* Added a focused integration test for the instructor `with-courses` read path.
* Updated the Postman manual smoke collection so it:

  * accepts omitted/missing `data` for ID-less `201 Created` responses
  * recovers `courseId` from `GET /api/v1/instructors/{instructorId}/with-courses`
  * reads `moduleId`, `lessonId`, and `assignmentId` from endpoints that return IDs in `data`
  * guards dependent requests to avoid sending empty route parameters
  * uses safer JSON parsing in updated scripts
  * skips publication-dependent student/enrollment/submission/certificate steps when no admin token is available and the course is not published

## Files Changed

* `ELearning.Infrastructure/Data/Repositories/InstructorReadRepository.cs`
* `ELearning.IntegrationTests/CourseAuthoringWorkflowIntegrationTests.cs`
* `postman/ELearning-Manual-Smoke.postman_collection.json`

## Validation

Validated locally with:

* `docker compose -p e-learningapp ps`
* `Invoke-RestMethod http://localhost:8080/health/live`
* `Invoke-RestMethod http://localhost:8080/health/ready`
* `dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false`
* `dotnet test ELearning.IntegrationTests\ELearning.IntegrationTests.csproj -nologo /p:UseSharedCompilation=false --filter "FullyQualifiedName~GetInstructorWithCourses_ReturnsCreatedDraftCourse"`
* `dotnet test ELearning.IntegrationTests\ELearning.IntegrationTests.csproj -nologo /p:UseSharedCompilation=false --filter "FullyQualifiedName~CourseAuthoringWorkflowIntegrationTests"`
* `docker compose -p e-learningapp up -d --build elearning-api`
* `npx newman run ".\POSTMAN\ELearning-Manual-Smoke.postman_collection.json" -e ".\POSTMAN\ELearning-Manual-Smoke.postman_environment.json" --env-var "baseUrl=http://localhost:8080"`

## Newman Result

The manual smoke collection now completes successfully:

* iterations: 1 executed, 0 failed
* requests: 20 executed, 0 failed
* test scripts: 18 executed, 0 failed
* prerequest scripts: 28 executed, 0 failed
* assertions: 21 executed, 0 failed

Confirmed behavior:

* health endpoints pass
* instructor/student auth flow passes
* course creation passes
* `courseId` recovery from `with-courses` works
* module, lesson, and assignment creation pass
* empty route parameters are no longer sent
* negative authorization checks still pass

## Known Limitation

The full student learning/certificate path is not executed unless an admin token is available and the course is approved/published.

This is intentional in the current collection behavior. Student enrollment is only valid for published courses, so the smoke test now skips those steps honestly instead of failing with invalid URLs or broken prerequisites.

A future improvement can add an admin-enabled full workflow smoke test.
