### PR TITLE
Return created resource IDs from REST create endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,25 @@ jobs:
         shell: bash
         run: |
           mkdir -p TestResults/ci
-          dotnet list ELearning.sln package --vulnerable --include-transitive > TestResults/ci/dependency-scan.txt
+          : > TestResults/ci/dependency-scan.txt
+
+          projects=(
+            "ELearning.API/ELearning.API.csproj"
+            "ELearning.Application/ELearning.Application.csproj"
+            "ELearning.Domain/ELearning.Domain.csproj"
+            "ELearning.Infrastructure/ELearning.Infrastructure.csproj"
+            "ELearning.SharedKernel/ELearning.SharedKernel.csproj"
+            "ELearning.Application.Tests/ELearning.Application.Tests.csproj"
+            "ELearning.IntegrationTests/ELearning.IntegrationTests.csproj"
+          )
+
+          for project in "${projects[@]}"; do
+            echo "Scanning $project" | tee -a TestResults/ci/dependency-scan.txt
+            dotnet list "$project" package --vulnerable --include-transitive | tee -a TestResults/ci/dependency-scan.txt
+          done
+
           cat TestResults/ci/dependency-scan.txt
+
           if grep -qi "has the following vulnerable packages" TestResults/ci/dependency-scan.txt; then
             echo "Vulnerable dependencies detected."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,70 +1,53 @@
 name: ci
 
 on:
-pull_request:
-push:
-branches:
-  - master
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
-build-test-quality:
-runs-on: ubuntu-latest
+  build-test-quality:
+    runs-on: ubuntu-latest
 
-steps:
-  - name: Checkout
-    uses: actions/checkout@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  - name: Setup .NET
-    uses: actions/setup-dotnet@v4
-    with:
-      dotnet-version: 10.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
 
-  - name: Restore
-    run: dotnet restore ELearning.sln
+      - name: Restore
+        run: dotnet restore ELearning.sln
 
-  - name: Build (analyzers enabled)
-    run: dotnet build ELearning.sln --no-restore -nologo
+      - name: Build (analyzers enabled)
+        run: dotnet build ELearning.sln --no-restore -nologo
 
-  - name: Lint (analyzers and nullable warnings gate)
-    run: dotnet build ELearning.sln --no-restore -nologo /warnaserror:nullable
+      - name: Lint (analyzers and nullable warnings gate)
+        run: dotnet build ELearning.sln --no-restore -nologo /warnaserror:nullable
 
-  - name: Test with coverage
-    run: dotnet test ELearning.sln --no-build -nologo --collect:"XPlat Code Coverage" --results-directory TestResults/ci
+      - name: Test with coverage
+        run: dotnet test ELearning.sln --no-build -nologo --collect:"XPlat Code Coverage" --results-directory TestResults/ci
 
-  - name: Dependency vulnerability scan (SCA)
-    shell: bash
-    run: |
-      mkdir -p TestResults/ci
-      : > TestResults/ci/dependency-scan.txt
+      - name: Dependency vulnerability scan (SCA)
+        shell: bash
+        run: |
+          mkdir -p TestResults/ci
+          dotnet list ELearning.sln package --vulnerable --include-transitive > TestResults/ci/dependency-scan.txt
+          cat TestResults/ci/dependency-scan.txt
+          if grep -qi "has the following vulnerable packages" TestResults/ci/dependency-scan.txt; then
+            echo "Vulnerable dependencies detected."
+            exit 1
+          fi
 
-      projects=(
-        "ELearning.API/ELearning.API.csproj"
-        "ELearning.Application/ELearning.Application.csproj"
-        "ELearning.Domain/ELearning.Domain.csproj"
-        "ELearning.Infrastructure/ELearning.Infrastructure.csproj"
-        "ELearning.SharedKernel/ELearning.SharedKernel.csproj"
-        "ELearning.Application.Tests/ELearning.Application.Tests.csproj"
-        "ELearning.IntegrationTests/ELearning.IntegrationTests.csproj"
-      )
-
-      for project in "${projects[@]}"; do
-        echo "Scanning $project" | tee -a TestResults/ci/dependency-scan.txt
-        dotnet list "$project" package --vulnerable --include-transitive | tee -a TestResults/ci/dependency-scan.txt
-      done
-
-      cat TestResults/ci/dependency-scan.txt
-
-      if grep -qi "has the following vulnerable packages" TestResults/ci/dependency-scan.txt; then
-        echo "Vulnerable dependencies detected."
-        exit 1
-      fi
-
-  - name: Upload quality artifacts
-    if: always()
-    uses: actions/upload-artifact@v4
-    with:
-      name: ci-quality-artifacts
-      path: |
-        TestResults/**/*.trx
-        TestResults/**/coverage.cobertura.xml
-        TestResults/ci/dependency-scan.txt
+      - name: Upload quality artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-quality-artifacts
+          path: |
+            TestResults/**/*.trx
+            TestResults/**/coverage.cobertura.xml
+            TestResults/ci/dependency-scan.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,12 @@ on:
 pull_request:
 push:
 branches:
-- master
+  - master
 
 jobs:
 build-test-quality:
 runs-on: ubuntu-latest
 
-```
 steps:
   - name: Checkout
     uses: actions/checkout@v4
@@ -69,4 +68,3 @@ steps:
         TestResults/**/*.trx
         TestResults/**/coverage.cobertura.xml
         TestResults/ci/dependency-scan.txt
-```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,53 +1,72 @@
 name: ci
 
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+pull_request:
+push:
+branches:
+- master
 
 jobs:
-  build-test-quality:
-    runs-on: ubuntu-latest
+build-test-quality:
+runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+```
+steps:
+  - name: Checkout
+    uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
+  - name: Setup .NET
+    uses: actions/setup-dotnet@v4
+    with:
+      dotnet-version: 10.0.x
 
-      - name: Restore
-        run: dotnet restore ELearning.sln
+  - name: Restore
+    run: dotnet restore ELearning.sln
 
-      - name: Build (analyzers enabled)
-        run: dotnet build ELearning.sln --no-restore -nologo
+  - name: Build (analyzers enabled)
+    run: dotnet build ELearning.sln --no-restore -nologo
 
-      - name: Lint (analyzers and nullable warnings gate)
-        run: dotnet build ELearning.sln --no-restore -nologo /warnaserror:nullable
+  - name: Lint (analyzers and nullable warnings gate)
+    run: dotnet build ELearning.sln --no-restore -nologo /warnaserror:nullable
 
-      - name: Test with coverage
-        run: dotnet test ELearning.sln --no-build -nologo --collect:"XPlat Code Coverage" --results-directory TestResults/ci
+  - name: Test with coverage
+    run: dotnet test ELearning.sln --no-build -nologo --collect:"XPlat Code Coverage" --results-directory TestResults/ci
 
-      - name: Dependency vulnerability scan (SCA)
-        shell: bash
-        run: |
-          mkdir -p TestResults/ci
-          dotnet list ELearning.sln package --vulnerable --include-transitive > TestResults/ci/dependency-scan.txt
-          cat TestResults/ci/dependency-scan.txt
-          if grep -qi "has the following vulnerable packages" TestResults/ci/dependency-scan.txt; then
-            echo "Vulnerable dependencies detected."
-            exit 1
-          fi
+  - name: Dependency vulnerability scan (SCA)
+    shell: bash
+    run: |
+      mkdir -p TestResults/ci
+      : > TestResults/ci/dependency-scan.txt
 
-      - name: Upload quality artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ci-quality-artifacts
-          path: |
-            TestResults/**/*.trx
-            TestResults/**/coverage.cobertura.xml
-            TestResults/ci/dependency-scan.txt
+      projects=(
+        "ELearning.API/ELearning.API.csproj"
+        "ELearning.Application/ELearning.Application.csproj"
+        "ELearning.Domain/ELearning.Domain.csproj"
+        "ELearning.Infrastructure/ELearning.Infrastructure.csproj"
+        "ELearning.SharedKernel/ELearning.SharedKernel.csproj"
+        "ELearning.Application.Tests/ELearning.Application.Tests.csproj"
+        "ELearning.IntegrationTests/ELearning.IntegrationTests.csproj"
+      )
+
+      for project in "${projects[@]}"; do
+        echo "Scanning $project" | tee -a TestResults/ci/dependency-scan.txt
+        dotnet list "$project" package --vulnerable --include-transitive | tee -a TestResults/ci/dependency-scan.txt
+      done
+
+      cat TestResults/ci/dependency-scan.txt
+
+      if grep -qi "has the following vulnerable packages" TestResults/ci/dependency-scan.txt; then
+        echo "Vulnerable dependencies detected."
+        exit 1
+      fi
+
+  - name: Upload quality artifacts
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: ci-quality-artifacts
+      path: |
+        TestResults/**/*.trx
+        TestResults/**/coverage.cobertura.xml
+        TestResults/ci/dependency-scan.txt
+```

--- a/ELearning.API/Controllers/CoursesController.cs
+++ b/ELearning.API/Controllers/CoursesController.cs
@@ -108,9 +108,9 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
 
     [HttpPost]
     [Authorize(Roles = "Instructor")]
-    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse<Guid>), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<ApiResponse<object?>>> CreateCourse(
+    public async Task<ActionResult<ApiResponse<Guid>>> CreateCourse(
         CreateCourseRequest request,
         CancellationToken cancellationToken)
     {
@@ -118,10 +118,10 @@ public class CoursesController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.FromError<object?>(result.ErrorDetails);
+            return this.FromError<Guid>(result.ErrorDetails);
         }
 
-        return this.CreatedResponse();
+        return this.StatusCode(StatusCodes.Status201Created, ApiResponse<Guid>.Success(result.Value));
     }
 
     [HttpPut("{id:guid}")]

--- a/ELearning.API/Controllers/EnrollmentsController.cs
+++ b/ELearning.API/Controllers/EnrollmentsController.cs
@@ -33,9 +33,9 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
 
     [HttpPost]
     [Authorize(Roles = "Student")]
-    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse<Guid>), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<ApiResponse<object?>>> CreateEnrollment(
+    public async Task<ActionResult<ApiResponse<Guid>>> CreateEnrollment(
         CreateEnrollmentRequest request,
         CancellationToken cancellationToken)
     {
@@ -43,10 +43,10 @@ public class EnrollmentsController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.FromError<object?>(result.ErrorDetails);
+            return this.FromError<Guid>(result.ErrorDetails);
         }
 
-        return this.CreatedResponse();
+        return this.StatusCode(StatusCodes.Status201Created, ApiResponse<Guid>.Success(result.Value));
     }
 
     [HttpPost("{id:guid}/lessons/{lessonId:guid}/start")]

--- a/ELearning.API/Controllers/SubmissionsController.cs
+++ b/ELearning.API/Controllers/SubmissionsController.cs
@@ -32,9 +32,9 @@ public class SubmissionsController(IApiFacade apiFacade) : ApiControllerBase
 
     [HttpPost]
     [Authorize(Roles = "Student")]
-    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse<Guid>), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<ApiResponse<object?>>> CreateSubmission(
+    public async Task<ActionResult<ApiResponse<Guid>>> CreateSubmission(
         CreateSubmissionRequest request,
         CancellationToken cancellationToken)
     {
@@ -42,10 +42,10 @@ public class SubmissionsController(IApiFacade apiFacade) : ApiControllerBase
         var result = await apiFacade.SendAsync(command, cancellationToken);
         if (!result.IsSuccess)
         {
-            return this.FromError<object?>(result.ErrorDetails);
+            return this.FromError<Guid>(result.ErrorDetails);
         }
 
-        return this.CreatedResponse();
+        return this.StatusCode(StatusCodes.Status201Created, ApiResponse<Guid>.Success(result.Value));
     }
 
     [HttpPost("{id:guid}/grade")]

--- a/ELearning.Application/Courses/Commands/CreateCourseCommand.cs
+++ b/ELearning.Application/Courses/Commands/CreateCourseCommand.cs
@@ -17,4 +17,4 @@ public record CreateCourseCommand(
     int LevelId,
     decimal Price,
     int DurationHours,
-    int DurationMinutes) : IRequest<Result>;
+    int DurationMinutes) : IRequest<Result<Guid>>;

--- a/ELearning.Application/Courses/Handlers/CreateCourseCommandHandler.cs
+++ b/ELearning.Application/Courses/Handlers/CreateCourseCommandHandler.cs
@@ -19,9 +19,9 @@ using MediatR;
 public class CreateCourseCommandHandler(ICourseRepository courseRepository,
         ICurrentUserService currentUserService,
         IUserRepository userRepository)
-    : IRequestHandler<CreateCourseCommand, Result>
+    : IRequestHandler<CreateCourseCommand, Result<Guid>>
 {
-    public async Task<Result> Handle(CreateCourseCommand request, CancellationToken cancellationToken)
+    public async Task<Result<Guid>> Handle(CreateCourseCommand request, CancellationToken cancellationToken)
     {
         if (!currentUserService.IsAuthenticated || currentUserService.UserId is null)
         {
@@ -41,7 +41,7 @@ public class CreateCourseCommandHandler(ICourseRepository courseRepository,
 
         if (category is null || level is null)
         {
-            return Result.Failure(ApplicationError.BadRequest(
+            return Result.Failure<Guid>(ApplicationError.BadRequest(
                 $"Invalid category or level. Category: {category?.Name ?? "null"}, Level: {level?.Name ?? "null"}"));
         }
 
@@ -60,6 +60,6 @@ public class CreateCourseCommandHandler(ICourseRepository courseRepository,
 
         await courseRepository.AddAsync(course, cancellationToken);
 
-        return Result.Success();
+        return Result.Success(course.Id);
     }
 }

--- a/ELearning.Application/Courses/Handlers/GetCourseDetailQueryHandler.cs
+++ b/ELearning.Application/Courses/Handlers/GetCourseDetailQueryHandler.cs
@@ -4,19 +4,22 @@
 
 namespace ELearning.Application.Courses.Handlers;
 
-using AutoMapper;
 using ELearning.Application.Common.Exceptions;
 using ELearning.Application.Common.Interfaces;
 using ELearning.Application.Common.Model;
+using ELearning.Application.Courses.Abstractions;
 using ELearning.Application.Courses.Dtos;
 using ELearning.Application.Courses.Queries;
+using ELearning.Application.Instructors.Dtos;
 using ELearning.Domain.Entities.CourseAggregate;
 using ELearning.Domain.Entities.CourseAggregate.Abstractions.Repositories;
+using ELearning.Domain.Entities.UserAggregate.Abstractions.Repositories;
 using MediatR;
 
 public class GetCourseDetailQueryHandler(
         ICourseRepository courseRepository,
-        IMapper mapper,
+        ICourseReadRepository courseReadRepository,
+        IInstructorReadRepository instructorReadRepository,
         ICurrentUserService currentUserService)
     : IRequestHandler<GetCourseDetailQuery, Result<CourseDto>>
 {
@@ -35,7 +38,64 @@ public class GetCourseDetailQueryHandler(
             throw new NotFoundException(nameof(Course), request.CourseId);
         }
 
-        var courseDto = mapper.Map<CourseDto>(course);
+        var instructor = await instructorReadRepository.GetByIdAsync(course.InstructorId, cancellationToken)
+            ?? throw new NotFoundException("Instructor", course.InstructorId);
+
+        var reviews = await courseReadRepository.GetReviewsByCourseIdAsync(request.CourseId, cancellationToken);
+
+        var courseDto = new CourseDto(
+            course.Id,
+            course.Title,
+            course.Description,
+            new InstructorDto(
+                instructor.Id,
+                instructor.FullName,
+                instructor.Email,
+                instructor.Bio,
+                instructor.Expertise,
+                instructor.ProfilePictureUrl ?? string.Empty,
+                instructor.AverageRating,
+                instructor.TotalStudents,
+                instructor.TotalCourses),
+            course.Status.Name,
+            course.Category.Name,
+            course.Level.Name,
+            course.Price,
+            course.Duration.ToString(),
+            course.PublishedDate,
+            course.AverageRating.Value,
+            course.AverageRating.NumberOfRatings,
+            [.. course.Modules
+                .OrderBy(module => module.Order)
+                .Select(module => new ModuleDto(
+                    module.Id,
+                    module.Title,
+                    module.Description,
+                    module.Order,
+                    [.. module.Lessons
+                        .OrderBy(lesson => lesson.Order)
+                        .Select(lesson => new LessonDto(
+                            lesson.Id,
+                            lesson.Title,
+                            lesson.Content,
+                            lesson.Type.Name,
+                            lesson.VideoUrl ?? string.Empty,
+                            lesson.Duration.ToString(),
+                            lesson.Order))],
+                    [.. module.Assignments
+                        .Select(assignment => new AssignmentDto(
+                            assignment.Id,
+                            assignment.Title,
+                            assignment.Description,
+                            assignment.Type.Name,
+                            assignment.MaxPoints,
+                            assignment.DueDate))]))],
+            [.. reviews.Select(review => new ReviewDto(
+                review.Id,
+                review.StudentName,
+                review.Rating,
+                review.Comment,
+                review.CreatedAt))]);
 
         return Result.Success(courseDto);
     }

--- a/ELearning.Application/Enrollments/Commands/CreateEnrollmentCommand.cs
+++ b/ELearning.Application/Enrollments/Commands/CreateEnrollmentCommand.cs
@@ -7,7 +7,7 @@ namespace ELearning.Application.Enrollments.Commands;
 using ELearning.Application.Common.Model;
 using MediatR;
 
-public sealed record CreateEnrollmentCommand : IRequest<Result>
+public sealed record CreateEnrollmentCommand : IRequest<Result<Guid>>
 {
     public Guid CourseId { get; init; }
 }

--- a/ELearning.Application/Enrollments/Handlers/CreateEnrollmentCommandHandler.cs
+++ b/ELearning.Application/Enrollments/Handlers/CreateEnrollmentCommandHandler.cs
@@ -22,9 +22,9 @@ public class CreateEnrollmentCommandHandler(
             IEnrollmentRepository enrollmentRepository,
             INotificationRequestService notificationRequestService,
             ICurrentUserService currentUserService)
-    : IRequestHandler<CreateEnrollmentCommand, Result>
+    : IRequestHandler<CreateEnrollmentCommand, Result<Guid>>
 {
-    public async Task<Result> Handle(CreateEnrollmentCommand request, CancellationToken cancellationToken)
+    public async Task<Result<Guid>> Handle(CreateEnrollmentCommand request, CancellationToken cancellationToken)
     {
         if (!currentUserService.IsAuthenticated || currentUserService.UserId is null)
         {
@@ -47,14 +47,14 @@ public class CreateEnrollmentCommandHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Failure(ApplicationError.Conflict(ex.Message));
+            return Result.Failure<Guid>(ApplicationError.Conflict(ex.Message));
         }
 
         // Check if student is already enrolled
         var alreadyEnrolled = await enrollmentRepository.GetByStudentAndCourseIdAsync(studentId, request.CourseId, cancellationToken) is not null;
         if (alreadyEnrolled)
         {
-            return Result.Failure(ApplicationError.Conflict("You are already enrolled in this course."));
+            return Result.Failure<Guid>(ApplicationError.Conflict("You are already enrolled in this course."));
         }
 
         var enrollment = new Enrollment(studentId, course.Id);
@@ -66,6 +66,6 @@ public class CreateEnrollmentCommandHandler(
             enrollment.Id,
             cancellationToken);
 
-        return Result.Success();
+        return Result.Success(enrollment.Id);
     }
 }

--- a/ELearning.Application/Submissions/Commands/CreateSubmissionCommand.cs
+++ b/ELearning.Application/Submissions/Commands/CreateSubmissionCommand.cs
@@ -7,7 +7,7 @@ namespace ELearning.Application.Submissions.Commands;
 using ELearning.Application.Common.Model;
 using MediatR;
 
-public sealed record CreateSubmissionCommand : IRequest<Result>
+public sealed record CreateSubmissionCommand : IRequest<Result<Guid>>
 {
     public Guid AssignmentId { get; init; }
 

--- a/ELearning.Application/Submissions/Handlers/CreateSubmissionCommandHandler.cs
+++ b/ELearning.Application/Submissions/Handlers/CreateSubmissionCommandHandler.cs
@@ -20,9 +20,9 @@ public class CreateSubmissionCommandHandler(
         IEnrollmentRepository enrollmentRepository,
         ICourseRepository courseRepository,
         CertificateIssuanceCoordinator certificateIssuanceCoordinator,
-        ICurrentUserService currentUserService) : IRequestHandler<CreateSubmissionCommand, Result>
+        ICurrentUserService currentUserService) : IRequestHandler<CreateSubmissionCommand, Result<Guid>>
 {
-    public async Task<Result> Handle(CreateSubmissionCommand request, CancellationToken cancellationToken)
+    public async Task<Result<Guid>> Handle(CreateSubmissionCommand request, CancellationToken cancellationToken)
     {
         if (!currentUserService.IsAuthenticated || currentUserService.UserId is null)
         {
@@ -38,36 +38,36 @@ public class CreateSubmissionCommandHandler(
         var module = await assignmentRepository.GetModuleForAssignmentAsync(request.AssignmentId, cancellationToken)
             ?? throw new NotFoundException("Module for assignment", request.AssignmentId);
 
+        var enrollment = await enrollmentRepository.GetByStudentAndCourseIdAsync(studentId, module.CourseId, cancellationToken)
+            ?? throw new StudentNotEnrolledException(studentId, module.CourseId);
+
         var course = await courseRepository.GetByIdForUpdateAsync(module.CourseId, cancellationToken)
             ?? throw new NotFoundException(nameof(Course), module.CourseId);
 
         if (!course.ContainsAssignment(request.AssignmentId))
         {
-            return Result.Failure(ApplicationError.Conflict("The assessment does not belong to the enrolled course."));
+            return Result.Failure<Guid>(ApplicationError.Conflict("The assessment does not belong to the enrolled course."));
         }
-
-        var enrollment = await enrollmentRepository.GetByStudentAndCourseIdAsync(studentId, module.CourseId, cancellationToken)
-            ?? throw new StudentNotEnrolledException(studentId, module.CourseId);
 
         try
         {
             course.EnsureAvailableForLearning();
             assignment.EnsureCanAcceptSubmissionAt(DateTime.UtcNow);
-            enrollment.SubmitAssignment(
+            var submission = enrollment.SubmitAssignment(
                 request.AssignmentId,
                 request.Content,
                 request.FileUrl,
                 course.GetTotalLessonCount(),
                 course.GetRequiredAssessmentIds());
+
+            await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);
+            await certificateIssuanceCoordinator.TryIssueForCompletedEnrollmentAsync(enrollment, course, cancellationToken);
+
+            return Result.Success(submission.Id);
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentOutOfRangeException)
         {
-            return Result.Failure(ApplicationError.Conflict(ex.Message));
+            return Result.Failure<Guid>(ApplicationError.Conflict(ex.Message));
         }
-
-        await enrollmentRepository.UpdateAsync(enrollment, cancellationToken);
-        await certificateIssuanceCoordinator.TryIssueForCompletedEnrollmentAsync(enrollment, course, cancellationToken);
-
-        return Result.Success();
     }
 }

--- a/ELearning.Domain/Entities/UserAggregate/Student.cs
+++ b/ELearning.Domain/Entities/UserAggregate/Student.cs
@@ -12,12 +12,12 @@ using ELearning.Domain.ValueObjects;
 
 public class Student : User
 {
-    private readonly Dictionary<Guid, Enrollment> enrollments = new();
+    private readonly List<Enrollment> enrollments = [];
 
     /// <summary>
     /// Gets courses this student is enrolled in.
     /// </summary>
-    public IReadOnlyCollection<Enrollment> Enrollments => this.enrollments.Values.ToList().AsReadOnly();
+    public IReadOnlyCollection<Enrollment> Enrollments => this.enrollments.AsReadOnly();
 
     private Student()
         : base()
@@ -31,22 +31,28 @@ public class Student : User
 
     public bool EnrollInCourse(Course course)
     {
-        if (course == null)
-        {
-            throw new ArgumentNullException(nameof(course));
-        }
+        ArgumentNullException.ThrowIfNull(course);
 
-        if (this.enrollments.ContainsKey(course.Id))
+        if (this.enrollments.Any(enrollment => enrollment.CourseId == course.Id))
         {
-            return false; // Already enrolled
+            return false;
         }
 
         var enrollment = new Enrollment(this.Id, course.Id, null, null);
-        this.enrollments[course.Id] = enrollment;
+        this.enrollments.Add(enrollment);
 
         this.AddDomainEvent(new EnrollmentCreatedEvent(this, course, enrollment));
         return true;
     }
 
-    public bool UnenrollFromCourse(Guid courseId) => this.enrollments.Remove(courseId);
+    public bool UnenrollFromCourse(Guid courseId)
+    {
+        var enrollment = this.enrollments.FirstOrDefault(existingEnrollment => existingEnrollment.CourseId == courseId);
+        if (enrollment is null)
+        {
+            return false;
+        }
+
+        return this.enrollments.Remove(enrollment);
+    }
 }

--- a/ELearning.Infrastructure/Data/Configurations/EnrollmentConfiguration.cs
+++ b/ELearning.Infrastructure/Data/Configurations/EnrollmentConfiguration.cs
@@ -34,7 +34,7 @@ public class EnrollmentConfiguration : IEntityTypeConfiguration<Enrollment>
 
         // Configure relationships
         builder.HasOne<Student>()
-            .WithMany(s => s.Enrollments)
+            .WithMany(student => student.Enrollments)
             .HasForeignKey(e => e.StudentId)
             .OnDelete(DeleteBehavior.Cascade);
 
@@ -43,9 +43,15 @@ public class EnrollmentConfiguration : IEntityTypeConfiguration<Enrollment>
             .HasForeignKey(p => p.EnrollmentId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.Navigation(e => e.ProgressRecords)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
         builder.HasMany(e => e.Submissions)
             .WithOne()
             .HasForeignKey(s => s.EnrollmentId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(e => e.Submissions)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/ELearning.Infrastructure/Data/Repositories/CourseRepository.cs
+++ b/ELearning.Infrastructure/Data/Repositories/CourseRepository.cs
@@ -28,6 +28,9 @@ public class CourseRepository : ICourseRepository
             .Include(c => c.Modules)
             .ThenInclude(m => m.Assignments)
             .Include(c => c.Enrollments)
+            .ThenInclude(e => e.Submissions)
+            .Include(c => c.Enrollments)
+            .ThenInclude(e => e.ProgressRecords)
             .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
     }
 

--- a/ELearning.Infrastructure/Data/Repositories/EnrollmentRepository.cs
+++ b/ELearning.Infrastructure/Data/Repositories/EnrollmentRepository.cs
@@ -7,6 +7,7 @@ namespace ELearning.Infrastructure.Data.Repositories;
 using ELearning.Domain.Entities.EnrollmentAggregate;
 using ELearning.Domain.Entities.EnrollmentAggregate.Abstractions.Repositories;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 public class EnrollmentRepository(ApplicationDbContext context) : IEnrollmentRepository
 {
@@ -23,15 +24,59 @@ public class EnrollmentRepository(ApplicationDbContext context) : IEnrollmentRep
         await context.Enrollments.AddAsync(entity, cancellationToken);
     }
 
-    public Task UpdateAsync(Enrollment entity, CancellationToken cancellationToken)
+    public async Task UpdateAsync(Enrollment entity, CancellationToken cancellationToken)
     {
         var entry = context.Entry(entity);
         if (entry.State == EntityState.Detached)
         {
             context.Enrollments.Attach(entity);
+            entry = context.Entry(entity);
         }
 
-        return Task.CompletedTask;
+        var rowVersionEntry = entry.Property(nameof(Enrollment.RowVersion));
+        if (rowVersionEntry.OriginalValue is null && rowVersionEntry.CurrentValue is not null)
+        {
+            rowVersionEntry.OriginalValue = rowVersionEntry.CurrentValue;
+        }
+
+        await this.TrackNewEnrollmentContentAsync(entity, cancellationToken);
+    }
+
+    private async Task TrackNewEnrollmentContentAsync(Enrollment enrollment, CancellationToken cancellationToken)
+    {
+        foreach (var progress in enrollment.ProgressRecords)
+        {
+            var progressEntry = context.Entry(progress);
+            await TrackAsAddedWhenMissingAsync(
+                progressEntry,
+                () => context.Progresses.AnyAsync(existingProgress => existingProgress.Id == progress.Id, cancellationToken));
+        }
+
+        foreach (var submission in enrollment.Submissions)
+        {
+            var submissionEntry = context.Entry(submission);
+            await TrackAsAddedWhenMissingAsync(
+                submissionEntry,
+                () => context.Submissions.AnyAsync(existingSubmission => existingSubmission.Id == submission.Id, cancellationToken));
+        }
+    }
+
+    private static async Task TrackAsAddedWhenMissingAsync(EntityEntry entry, Func<Task<bool>> existsInDatabase)
+    {
+        if (entry.State == EntityState.Added)
+        {
+            return;
+        }
+
+        if (entry.State is not (EntityState.Detached or EntityState.Modified))
+        {
+            return;
+        }
+
+        if (!await existsInDatabase())
+        {
+            entry.State = EntityState.Added;
+        }
     }
 
     public Task DeleteAsync(Enrollment entity, CancellationToken cancellationToken)

--- a/ELearning.IntegrationTests/CourseAuthoringWorkflowIntegrationTests.cs
+++ b/ELearning.IntegrationTests/CourseAuthoringWorkflowIntegrationTests.cs
@@ -46,14 +46,16 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
         var title = CreateUniqueTitle("create-course");
 
         var response = await this.PostAsRoleAsync(
-            "/api/courses",
+            "/api/v1/courses",
             CreateCourseRequest(title),
             instructorId,
             "Instructor",
             cancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var createdCourseId = await ReadResponseDataIdAsync(response, cancellationToken);
         var course = await this.GetCourseByTitleAsync(title, cancellationToken);
+        createdCourseId.Should().Be(course.Id);
         course.InstructorId.Should().Be(instructorId);
         course.Status.Should().Be(CourseStatus.Draft);
     }
@@ -89,7 +91,7 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
         var courseId = await this.CreateCourseAsync(instructorId, CreateUniqueTitle("submit-empty"), cancellationToken);
 
         var response = await this.PostAsRoleAsync(
-            $"/api/courses/{courseId}/submit-for-review",
+            $"/api/v1/courses/{courseId}/submit-for-review",
             null,
             instructorId,
             "Instructor",
@@ -179,14 +181,14 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
         var rejectionCourseId = await this.CreateSubmittedCourseAsync(instructorId, CreateUniqueTitle("reject"), cancellationToken);
 
         var approveResponse = await this.PostAsRoleAsync(
-            $"/api/courses/{approvalCourseId}/approve-publication",
+            $"/api/v1/courses/{approvalCourseId}/approve-publication",
             null,
             adminId,
             "Admin",
             cancellationToken);
 
         var rejectResponse = await this.PostAsRoleAsync(
-            $"/api/courses/{rejectionCourseId}/reject-publication",
+            $"/api/v1/courses/{rejectionCourseId}/reject-publication",
             new
             {
                 CourseId = rejectionCourseId,
@@ -206,6 +208,45 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
         rejectedCourse.RejectionReason.Should().Be("Add a clearer module introduction before publishing.");
     }
 
+    [Fact]
+    public async Task StudentCreatesEnrollment_ReturnsCreatedIdAndPersistsEnrollment()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var instructorId = await this.SeedInstructorAsync(cancellationToken);
+        var studentId = await this.SeedStudentAsync(cancellationToken);
+        var courseId = await this.CreatePublishedCourseAsync(instructorId, CreateUniqueTitle("enroll"), cancellationToken);
+
+        var enrollmentId = await this.CreateEnrollmentAsync(studentId, courseId, cancellationToken);
+
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var enrollment = await dbContext.Enrollments.SingleAsync(e => e.Id == enrollmentId, cancellationToken);
+        enrollment.StudentId.Should().Be(studentId);
+        enrollment.CourseId.Should().Be(courseId);
+    }
+
+    [Fact]
+    public async Task StudentCreatesSubmission_ReturnsCreatedIdAndPersistsSubmission()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var instructorId = await this.SeedInstructorAsync(cancellationToken);
+        var studentId = await this.SeedStudentAsync(cancellationToken);
+        var courseId = await this.CreatePublishedCourseWithAssignmentAsync(
+            instructorId,
+            CreateUniqueTitle("submission"),
+            cancellationToken);
+        var assignmentId = await this.GetFirstAssignmentIdAsync(courseId, cancellationToken);
+        var enrollmentId = await this.CreateEnrollmentAsync(studentId, courseId, cancellationToken);
+
+        var submissionId = await this.CreateSubmissionAsync(studentId, assignmentId, cancellationToken);
+
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var submission = await dbContext.Submissions.SingleAsync(s => s.Id == submissionId, cancellationToken);
+        submission.EnrollmentId.Should().Be(enrollmentId);
+        submission.AssignmentId.Should().Be(assignmentId);
+    }
+
     private async Task<Guid> CreateAuthoredCourseAsync(Guid instructorId, string title, CancellationToken cancellationToken)
     {
         var courseId = await this.CreateCourseAsync(instructorId, title, cancellationToken);
@@ -218,7 +259,7 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
     {
         var courseId = await this.CreateAuthoredCourseAsync(instructorId, title, cancellationToken);
         var response = await this.PostAsRoleAsync(
-            $"/api/courses/{courseId}/submit-for-review",
+            $"/api/v1/courses/{courseId}/submit-for-review",
             null,
             instructorId,
             "Instructor",
@@ -228,19 +269,60 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
         return courseId;
     }
 
+    private async Task<Guid> CreatePublishedCourseAsync(Guid instructorId, string title, CancellationToken cancellationToken)
+    {
+        var courseId = await this.CreateSubmittedCourseAsync(instructorId, title, cancellationToken);
+        var response = await this.PostAsRoleAsync(
+            $"/api/v1/courses/{courseId}/approve-publication",
+            null,
+            Guid.NewGuid(),
+            "Admin",
+            cancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return courseId;
+    }
+
+    private async Task<Guid> CreatePublishedCourseWithAssignmentAsync(Guid instructorId, string title, CancellationToken cancellationToken)
+    {
+        var courseId = await this.CreateCourseAsync(instructorId, title, cancellationToken);
+        var moduleId = await this.AddModuleAsync(courseId, instructorId, cancellationToken);
+        await this.AddLessonAsync(courseId, moduleId, instructorId, cancellationToken);
+        await this.AddAssignmentAsync(courseId, moduleId, instructorId, cancellationToken);
+        var submitResponse = await this.PostAsRoleAsync(
+            $"/api/v1/courses/{courseId}/submit-for-review",
+            null,
+            instructorId,
+            "Instructor",
+            cancellationToken);
+        submitResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var approveResponse = await this.PostAsRoleAsync(
+            $"/api/v1/courses/{courseId}/approve-publication",
+            null,
+            Guid.NewGuid(),
+            "Admin",
+            cancellationToken);
+        approveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        return courseId;
+    }
+
     private async Task<Guid> CreateCourseAsync(Guid instructorId, string title, CancellationToken cancellationToken)
     {
         var response = await this.PostAsRoleAsync(
-            "/api/courses",
+            "/api/v1/courses",
             CreateCourseRequest(title),
             instructorId,
             "Instructor",
             cancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var courseId = await ReadResponseDataIdAsync(response, cancellationToken);
         var course = await this.GetCourseByTitleAsync(title, cancellationToken);
+        courseId.Should().Be(course.Id);
         course.RowVersion.Should().NotBeNull();
-        return course.Id;
+        return courseId;
     }
 
     private async Task<Guid> AddModuleAsync(Guid courseId, Guid instructorId, CancellationToken cancellationToken)
@@ -339,6 +421,24 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
         return instructor.Id;
     }
 
+    private async Task<Guid> SeedStudentAsync(CancellationToken cancellationToken)
+    {
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
+        var uniqueValue = Guid.NewGuid().ToString("N");
+
+        var student = new Student(
+            firstName: "Integration",
+            lastName: "Student",
+            email: Email.Create($"course.student.{uniqueValue}@tests.io"),
+            passwordHash: passwordHasher.HashPassword("P@ssword123!"));
+
+        dbContext.Students.Add(student);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return student.Id;
+    }
+
     private async Task<Course> GetCourseByTitleAsync(
         string title,
         CancellationToken cancellationToken)
@@ -357,6 +457,59 @@ public sealed class CourseAuthoringWorkflowIntegrationTests : IClassFixture<Real
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         return await dbContext.Courses
             .SingleAsync(course => course.Id == courseId, cancellationToken);
+    }
+
+    private async Task<Guid> GetFirstAssignmentIdAsync(Guid courseId, CancellationToken cancellationToken)
+    {
+        using var scope = this.factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var moduleIds = await dbContext.Modules
+            .Where(module => module.CourseId == courseId)
+            .Select(module => module.Id)
+            .ToListAsync(cancellationToken);
+
+        return await dbContext.Assignments
+            .Where(assignment => moduleIds.Contains(assignment.ModuleId))
+            .Select(assignment => assignment.Id)
+            .SingleAsync(cancellationToken);
+    }
+
+    private async Task<Guid> CreateEnrollmentAsync(Guid studentId, Guid courseId, CancellationToken cancellationToken)
+    {
+        var response = await this.PostAsRoleAsync(
+            "/api/v1/enrollments",
+            new
+            {
+                CourseId = courseId,
+            },
+            studentId,
+            "Student",
+            cancellationToken);
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.Created,
+            await response.Content.ReadAsStringAsync(cancellationToken));
+        return await ReadResponseDataIdAsync(response, cancellationToken);
+    }
+
+    private async Task<Guid> CreateSubmissionAsync(Guid studentId, Guid assignmentId, CancellationToken cancellationToken)
+    {
+        var response = await this.PostAsRoleAsync(
+            "/api/v1/submissions",
+            new
+            {
+                AssignmentId = assignmentId,
+                Content = "Integration test submission content.",
+                FileUrl = string.Empty,
+            },
+            studentId,
+            "Student",
+            cancellationToken);
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.Created,
+            await response.Content.ReadAsStringAsync(cancellationToken));
+        return await ReadResponseDataIdAsync(response, cancellationToken);
     }
 
     private static object CreateCourseRequest(string title) => new

--- a/postman/ELearning-Manual-Smoke.postman_collection.json
+++ b/postman/ELearning-Manual-Smoke.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "c5f4d245-5528-4b0e-b947-1c9e3c8f6a11",
     "name": "E-Learning Manual Smoke",
-    "description": "Manual shadow/smoke workflow for the E-Learning backend portfolio API.\n\nKnown blockers and notes:\n- No public admin registration/bootstrap endpoint exists in the REST API. Admin approval requests are included as optional/manual and require an out-of-band admin token.\n- CreateCourse, CreateEnrollment, and CreateSubmission return 201 with data = null, so IDs must be recovered from follow-up read endpoints.\n- /health/ready checks database readiness only; it does not verify RabbitMQ readiness.\n- Prefer /api/v1 routes throughout this collection.\n- Draft course recovery uses GET /api/v1/instructors/{{instructorId}}/with-courses by exact uniqueCourseTitle match.\n- For a stronger demo, the happy path adds a module, lesson, and assignment before submit-for-review.",
+    "description": "Manual shadow/smoke workflow for the E-Learning backend portfolio API.\n\nKnown blockers and notes:\n- No public admin registration/bootstrap endpoint exists in the REST API. Admin approval requests are included as optional/manual and require an out-of-band admin token.\n- CreateCourse, CreateEnrollment, and CreateSubmission now return created IDs directly in the response body.\n- /health/ready checks database readiness only; it does not verify RabbitMQ readiness.\n- Prefer /api/v1 routes throughout this collection.\n- GET /api/v1/instructors/{{instructorId}}/with-courses remains as optional draft-course visibility verification.\n- For a stronger demo, the happy path adds a module, lesson, and assignment before submit-for-review.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [],
@@ -456,9 +456,10 @@
                   "})();",
                   "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
-                  "pm.test('Create course does not require a created ID in the response body', function () {",
-                  "  pm.expect(body.data === null || typeof body.data === 'undefined').to.eql(true);",
-                  "});"
+                  "pm.test('Create course returns created courseId', function () {",
+                  "  pm.expect(body.data).to.be.a('string').and.not.empty;",
+                  "});",
+                  "pm.environment.set('courseId', body.data);"
                 ]
               }
             }
@@ -490,7 +491,7 @@
                 "courses"
               ]
             },
-            "description": "Creates a draft course. The API returns 201 with data = null, so recover courseId via the next request."
+            "description": "Creates a draft course and stores the created courseId directly from the response body."
           },
           "response": []
         },
@@ -565,7 +566,7 @@
                 "with-courses"
               ]
             },
-            "description": "Recovers draft courseId by matching uniqueCourseTitle. This is the preferred recovery path for newly created draft courses."
+            "description": "Optional verification that the authored draft course is visible to the instructor by unique title."
           },
           "response": []
         },
@@ -860,14 +861,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "const courseStatus = pm.environment.get('courseStatus');",
-                  "const missing = ['courseId'].filter(name => !pm.environment.get(name));",
-                  "if (missing.length > 0 || courseStatus !== 'Published') {",
-                  "  const reasons = missing.slice();",
-                  "  if (courseStatus !== 'Published') {",
-                  "    reasons.push(`courseStatus=${courseStatus || 'missing'} (published course required)`);",
-                  "  }",
-                  "  console.warn(`Skipping request because prerequisites are not satisfied: ${reasons.join(', ')}`);",
+                  "const missing = ['courseId', 'instructorToken'].filter(name => !pm.environment.get(name));",
+                  "if (missing.length > 0) {",
+                  "  console.warn(`Skipping request because prerequisites are not satisfied: ${missing.join(', ')}`);",
                   "  if (pm.execution && typeof pm.execution.skipRequest === 'function') {",
                   "    pm.execution.skipRequest();",
                   "  }",
@@ -920,7 +916,7 @@
                 "{{courseId}}"
               ]
             },
-            "description": "Optional owner verification for the authored course."
+            "description": "Owner verification for the authored course during the instructor flow."
           },
           "response": []
         }
@@ -1117,9 +1113,10 @@
                   "if (pm.response.code === 201) {",
                   "  pm.environment.set('enrollmentCreated', 'true');",
                   "}",
-                  "pm.test('Create enrollment does not require a created ID in the response body', function () {",
-                  "  pm.expect(body.data === null || typeof body.data === 'undefined').to.eql(true);",
-                  "});"
+                  "pm.test('Create enrollment returns created enrollmentId', function () {",
+                  "  pm.expect(body.data).to.be.a('string').and.not.empty;",
+                  "});",
+                  "pm.environment.set('enrollmentId', body.data);"
                 ]
               }
             }
@@ -1283,12 +1280,7 @@
                   "  }",
                   "})();",
                   "pm.expect(body, 'JSON response body').to.be.an('object');",
-                  "pm.expect(body.succeeded).to.eql(true);",
-                  "const submissions = (body.data && body.data.submissions) || [];",
-                  "const match = submissions.find(s => s.assignmentId === pm.environment.get('assignmentId'));",
-                  "if (match) {",
-                  "  pm.environment.set('submissionId', match.id);",
-                  "}"
+                  "pm.expect(body.succeeded).to.eql(true);"
                 ]
               }
             }
@@ -1479,9 +1471,10 @@
                   "})();",
                   "pm.expect(body, 'JSON response body').to.be.an('object');",
                   "pm.expect(body.succeeded).to.eql(true);",
-                  "pm.test('Create submission does not require a created ID in the response body', function () {",
-                  "  pm.expect(body.data === null || typeof body.data === 'undefined').to.eql(true);",
-                  "});"
+                  "pm.test('Create submission returns created submissionId', function () {",
+                  "  pm.expect(body.data).to.be.a('string').and.not.empty;",
+                  "});",
+                  "pm.environment.set('submissionId', body.data);"
                 ]
               }
             }
@@ -1517,7 +1510,7 @@
           "response": []
         },
         {
-          "name": "GET /api/v1/enrollments/{{enrollmentId}} (Recover submissionId)",
+          "name": "GET /api/v1/enrollments/{{enrollmentId}} (Verify submission)",
           "event": [
             {
               "listen": "prerequest",
@@ -1586,6 +1579,7 @@
               ]
             }
           },
+          "description": "Optional verification that the submission is visible on the enrollment detail after direct submissionId capture.",
           "response": []
         },
         {


### PR DESCRIPTION
### Summary

This PR updates the REST create endpoints so newly created resources return their IDs in `ApiResponse<Guid>.Data`.

Updated endpoints:

* `POST /api/v1/courses`
* `POST /api/v1/enrollments`
* `POST /api/v1/submissions`

This makes the REST API easier to consume from manual clients, Postman smoke tests, and future integration scenarios.

### Changes

* Changed relevant create commands and handlers from `Result` to `Result<Guid>`.
* Updated REST controllers to return created resource IDs in the response payload.
* Kept public GraphQL payload behavior unchanged.
* Updated the Postman smoke collection to store:

  * `courseId` from course creation
  * `enrollmentId` from enrollment creation
  * `submissionId` from submission creation
* Moved `GET /api/v1/courses/{{courseId}}` into the instructor authoring flow so the created course can be verified before publication.
* Fixed `GetCourseDetailQueryHandler` by replacing the missing AutoMapper mapping with explicit DTO construction.
* Fixed the EF Core enrollment/student relationship to avoid accidental `Enrollment.StudentId1` shadow FK creation.
* Preserved the existing migration history; no migration was added because `StudentId1` was an accidental model change, not an intended schema change.

### Validation

Completed successfully:

* `dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false`
* Targeted `CourseAuthoringWorkflowIntegrationTests`: `10/10`
* Targeted `GraphQLIntegrationTests`: `4/4`
* `dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false`

  * `ELearning.Application.Tests`: `110/110`
  * `ELearning.IntegrationTests`: `62/62`
* Docker API container stayed `Up (healthy)`.
* Docker logs showed:

  * no `Enrollment.StudentId1` warning
  * no pending model changes crash
  * database already up to date
* Health checks passed:

  * `GET /health/live`
  * `GET /health/ready`
* Newman manual smoke test passed with `0` failed assertions.

### Newman Smoke-Test Notes

Some student learning, submission, review, and certificate steps are still skipped when the optional admin publication flow is not executed.

Reason:

* `adminToken` is missing
* course remains `Draft`
* student enrollment requires a published course
* therefore no `enrollmentId`, `submissionId`, or `certificateCode` is created

This is expected for the current manual smoke collection and is not related to the returned ID fix.

### Review Checklist

* [ ] REST create endpoints return created IDs in `ApiResponse<Guid>.Data`.
* [ ] GraphQL public payload behavior remains unchanged.
* [ ] No accidental migration was added.
* [ ] EF Core no longer creates `Enrollment.StudentId1`.
* [ ] `GET /api/v1/courses/{{courseId}}` works in the instructor authoring flow.
* [ ] Postman smoke collection uses returned IDs directly where available.
* [ ] Newman passes with `0` failed assertions.
* [ ] Skipped Newman steps are only prerequisite/admin-publication-related skips.
* [ ] Docker API container is healthy.
* [ ] No frontend, SaaS, multi-tenancy, or broad architecture changes were introduced.
