### PR TITLE
Align vulnerability scan documentation with CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,25 @@ Preferred validation commands:
 dotnet restore ELearning.sln
 dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false
 dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
-dotnet list ELearning.sln package --vulnerable --include-transitive
 docker compose config
 kubectl kustomize deploy/kubernetes/base
 ```
 
 Use targeted tests when possible for small changes.
+
+Dependency vulnerability scan, matching CI:
+
+```powershell
+dotnet list ELearning.API/ELearning.API.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Application/ELearning.Application.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Domain/ELearning.Domain.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Infrastructure/ELearning.Infrastructure.csproj package --vulnerable --include-transitive
+dotnet list ELearning.SharedKernel/ELearning.SharedKernel.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Application.Tests/ELearning.Application.Tests.csproj package --vulnerable --include-transitive
+dotnet list ELearning.IntegrationTests/ELearning.IntegrationTests.csproj package --vulnerable --include-transitive
+```
+
+If new SDK-style `.csproj` projects are added later, keep this documentation and the CI project list aligned.
 
 ## Provider Defaults
 

--- a/README.md
+++ b/README.md
@@ -172,12 +172,23 @@ kubectl kustomize deploy/kubernetes/base
 dotnet restore ELearning.sln
 dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false
 dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
-dotnet list ELearning.sln package --vulnerable --include-transitive
 docker compose config
 kubectl kustomize deploy/kubernetes/base
 ```
 
 The validation commands above let readers run the current test suite and deployment checks locally.
+
+Dependency vulnerability scan, matching CI:
+
+```powershell
+dotnet list ELearning.API/ELearning.API.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Application/ELearning.Application.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Domain/ELearning.Domain.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Infrastructure/ELearning.Infrastructure.csproj package --vulnerable --include-transitive
+dotnet list ELearning.SharedKernel/ELearning.SharedKernel.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Application.Tests/ELearning.Application.Tests.csproj package --vulnerable --include-transitive
+dotnet list ELearning.IntegrationTests/ELearning.IntegrationTests.csproj package --vulnerable --include-transitive
+```
 
 ## Documentation
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,7 +44,18 @@ Pipeline:
 dotnet restore ELearning.sln
 dotnet build ELearning.sln -nologo /p:UseSharedCompilation=false
 dotnet test ELearning.sln -nologo /p:UseSharedCompilation=false
-dotnet list ELearning.sln package --vulnerable --include-transitive
+```
+
+Dependency vulnerability scan, matching CI:
+
+```powershell
+dotnet list ELearning.API/ELearning.API.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Application/ELearning.Application.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Domain/ELearning.Domain.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Infrastructure/ELearning.Infrastructure.csproj package --vulnerable --include-transitive
+dotnet list ELearning.SharedKernel/ELearning.SharedKernel.csproj package --vulnerable --include-transitive
+dotnet list ELearning.Application.Tests/ELearning.Application.Tests.csproj package --vulnerable --include-transitive
+dotnet list ELearning.IntegrationTests/ELearning.IntegrationTests.csproj package --vulnerable --include-transitive
 ```
 
 Deployment artifact checks:


### PR DESCRIPTION
## Summary

This PR updates public validation documentation so dependency vulnerability scan guidance matches the existing CI workflow.

The CI already scans individual SDK-style `.csproj` projects instead of running a solution-level vulnerability scan. This avoids the Visual Studio Docker Compose project issue with `docker-compose.dcproj`.

## Changes

- Updated `README.md` to keep the main validation block readable and add a separate per-project dependency vulnerability scan section.
- Updated `docs/testing.md` with the same per-project vulnerability scan guidance.
- Updated `AGENTS.md` with the same guidance.
- Added a short `AGENTS.md` maintenance note to keep docs and CI aligned when new SDK-style `.csproj` projects are added.

## Validation

- Confirmed the old solution-level vulnerability scan command no longer appears in:
  - `README.md`
  - `docs/testing.md`
  - `AGENTS.md`
- Confirmed the documented project list matches the existing CI workflow.
- Confirmed this is documentation-only.

## Notes

No code, CI, test, Docker, Kubernetes, or runtime behavior was changed.